### PR TITLE
Build the TEA specification from upstream source into ECMA HTML/PDF

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '18'
+          node-version-file: '.nvmrc'
 
       - name: Install Dependencies
         run: npm ci --no-audit --no-fund --verbose
@@ -28,7 +28,7 @@ jobs:
           PUPPETEER_SKIP_DOWNLOAD: "true"
 
       - name: Cache node_modules
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -39,15 +39,15 @@ jobs:
     needs: install
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '18'
+          node-version-file: '.nvmrc'
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -56,7 +56,7 @@ jobs:
         run: npm run build
 
       - name: Archive "out" Directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: html-documentation
           path: ./out
@@ -72,18 +72,18 @@ jobs:
       id-token: write
     steps:
       - name: Restore html-documentation Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: html-documentation
           path: ./out
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./out
 
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   build-for-pdf:
     name: 'Build Documentation for PDF'
@@ -91,15 +91,15 @@ jobs:
     needs: install
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '18'
+          node-version-file: '.nvmrc'
 
       - name: Restore node_modules
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: node_modules
           key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
@@ -108,7 +108,7 @@ jobs:
         run: npm run build-for-pdf
 
       - name: Archive PDF Output Directory
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: html-printable-documentation
           path: ./out
@@ -119,7 +119,7 @@ jobs:
     needs: build-for-pdf
     steps:
       - name: Restore PDF Output
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: html-printable-documentation
           path: ./out
@@ -133,7 +133,7 @@ jobs:
             --script /usr/local/lib/node_modules/ecmarkup/js/print.js /work/index.html -o /work/spec.pdf
 
       - name: Archive PDF
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: pdf-snapshot
           path: ./out/spec.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ vendor/esmeta
 test*.js
 aspell.txt
 
+# Fetched TEA source repository (populated by `npm run generate-spec`)
+tea-source/
+
 # lockfiles we don't use are ignored
 npm-shrinkwrap.json
 yarn.lock

--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ in the OWASP/CycloneDX TEA source repository:
 
 > <https://github.com/CycloneDX/transparency-exchange-api>
 
-Two sources of truth are pulled from there at build time:
+Three things are pulled from there at build time (see
+[What gets pulled from the TEA source](#what-gets-pulled-from-the-tea-source)
+for the exact details):
 
-- `spec/openapi.yaml` — the API surface and data model are generated from it.
-- The narrative Markdown files (discovery, authentication, use cases, the TEA
-  object model, signatures, …) — imported verbatim as specification prose.
+- `spec/openapi.yaml` — the API surface and the data model are generated from it.
+- A curated, ordered list of narrative Markdown files — imported as
+  specification prose.
+- The `## Introduction` section of the upstream `README.md` — used as the
+  spec's Introduction.
 
 This repository owns the **publication pipeline**: it converts those sources
 into an [Ecmarkup](https://github.com/tc39/ecmarkup) document and renders it to
@@ -52,6 +56,102 @@ CycloneDX/transparency-exchange-api  (Markdown + OpenAPI)
 | `lib/openapi-to-emu.js` | OpenAPI → API-surface and data-model clauses. |
 | `excerpts/` | Hand-authored front/back matter (header, scope, conformance, references, terms, bibliography, colophon). |
 | `spec.html` | Generated Ecmarkup source, committed for reviewer diff-ability. |
+
+## What gets pulled from the TEA source
+
+All three inputs are fetched from
+`https://raw.githubusercontent.com/CycloneDX/transparency-exchange-api/<ref>/<path>`.
+The `<ref>` is set by `TEA_SOURCE_REF` in `index.js` and currently tracks
+`main` (there is a `TODO` to pin it to a tag or commit before the first
+publication build, for reproducibility). Fetched files are cached under
+`tea-source/` (git-ignored) so repeated builds don't re-download.
+
+### Narrative Markdown — an explicit, ordered allowlist
+
+The narrative chapters are **not** discovered by a glob and it is **not**
+"every `.md` file in the repo". They come from a hand-curated list,
+`NARRATIVE_DOCS` in `index.js`. Each entry is `[pathInTeaRepo, idPrefix]`:
+
+```js
+const NARRATIVE_DOCS = [
+  ["doc/tea-requirements.md", "req"],
+  ["doc/tea-usecases.md", "uc"],
+  ["discovery/readme.md", "discovery"],
+  ["auth/readme.md", "auth"],
+  ["api-flow/consumer.md", "flow-consumer"],
+  ["api-flow/publisher.md", "flow-publisher"],
+  ["tea-product/tea-product.md", "tea-product"],
+  ["tea-product/tea-product-release.md", "tea-product-release"],
+  ["tea-component/tea-component.md", "tea-component"],
+  ["tea-component/tea-release.md", "tea-release"],
+  ["tea-collection/tea-collection.md", "tea-collection"],
+  ["tea-artifact/tea-artifact.md", "tea-artifact"],
+  ["signatures/signature.md", "signatures"],
+];
+```
+
+- **Ordering is significant.** Chapters appear in the rendered specification
+  in exactly the order listed here — this is an editorial decision, not
+  filesystem or alphabetical order.
+- **`idPrefix` gives stable, collision-free clause IDs.** Each Markdown
+  heading becomes an `<emu-clause>` whose ID is
+  `sec-<idPrefix>-<n>-<slug-of-heading>` (the `<n>` is a per-document counter).
+  The prefix namespaces the IDs so two chapters can use the same heading text
+  (e.g. "Overview") without producing duplicate IDs, and so that
+  cross-references and deep links stay stable across rebuilds.
+- **Conversion.** `lib/md-to-emu.js` maps Markdown headings (`#`…`######`) to
+  nested clauses, strips the leading table-of-contents bullet list that some
+  documents carry (Ecmarkup builds its own TOC), and drops code-fence language
+  hints that the bundled highlighter can't parse (e.g. `mermaid`, `abnf`,
+  `http`).
+- **Missing files degrade gracefully.** If a path 404s, the build logs a
+  warning and skips it rather than failing — so an upstream rename won't break
+  CI, but the affected chapter silently disappears until the list is updated.
+
+**Why a curated list and not a glob:** (1) chapter order in a standard is
+editorial; (2) the TEA repo contains Markdown that must *not* be published
+(e.g. `README.md`, contributor notes, implementation lists); and (3) stable
+clause IDs need the per-file `idPrefix`. The flip side: when the working group
+adds or renames a chapter upstream, **this list is the editorial control point
+that must be updated here** for the change to appear in the spec.
+
+### `spec/openapi.yaml` — generated API surface and data model
+
+`lib/openapi-to-emu.js` loads the document (bundling internal `$ref`s while
+preserving named-schema identity) and emits two top-level clauses:
+
+1. **The TEA API** (`#sec-tea-api`). Operations are grouped into a subclause
+   per OpenAPI **tag** (`#sec-tea-api-<tag>`). For every operation it renders:
+   - a heading from the operation `summary` (falling back to `operationId`),
+     under a stable ID `#sec-tea-op-<operationId>`;
+   - the HTTP method and path;
+   - the operation `description`;
+   - a **Parameters** table — name, location (`in`), required, type, description;
+   - the **request body** — media type and schema;
+   - a **Responses** table — status code, description, response schema.
+
+   If `info.description` is present and not the placeholder `TBC`, it is
+   rendered as the section's lead paragraph. Operations with no tag are
+   collected under an "Other operations" subclause.
+
+2. **Data model** (`#sec-tea-data-model`). One subclause per entry in
+   `components.schemas`, ID `#sec-tea-schema-<name>`, rendering: the schema
+   `description`, `type`, `format`, `pattern`, an **enum** table (if any), a
+   **Properties** table (property, type, Required/Optional, description), and
+   any `examples`/`example`. Property and parameter types that reference
+   another schema are linked to that schema's clause, so the data model is
+   cross-referenced.
+
+> Note: `oneOf` / `anyOf` / `allOf` are currently surfaced as the type name
+> only; the variants are not yet recursed into. The build also expects internal
+> (`#/components/...`) refs only — there are no external `$ref`s in the current
+> document.
+
+### `README.md` — Introduction only
+
+Only the `## Introduction` section of the upstream `README.md` is extracted
+(by `index.js`) and rendered as the spec's Introduction. The rest of that
+README is ignored.
 
 ## Building locally
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,81 @@
-# ECMA-xxx-PURL (Package-URL Specification)
+# ECMA-xxx-TEA (Transparency Exchange API Specification)
 
-This repository hosts the work-in-progress technical specification for **Package-URL (PURL)**, which is being developed under Ecma International's **Technical Committee 54 (TC54)**. PURL provides a lightweight, URL-based syntax for identifying software packages across diverse ecosystems, enabling interoperability, traceability, and improved supply chain management.
-
-## Purpose of the Repository
-
-The repository serves as the collaborative workspace for drafting, reviewing, and refining the PURL specification. Contributions from TC54 and its task groups (e.g., TG2) ensure that the specification aligns with international standardization goals and reflects the needs of global stakeholders.
-
-### Key Objectives
-- To develop the normative specification for the PURL syntax, its required components, and conformance requirements.
-- To provide a clear, authoritative reference for implementers, developers, and organisations adopting PURL.
-- To maintain transparency and encourage participation from all stakeholders.
+This repository hosts the work-in-progress technical specification for the
+**Transparency Exchange API (TEA)**, being developed under Ecma International's
+**Technical Committee 54 (TC54)**. TEA standardises the exchange of software,
+hardware and system transparency artefacts — such as Bills of Materials (xBOMs),
+attestations, and vulnerability disclosure documents — between publishers and
+consumers.
 
 ### Important Note on Repository Name
 
-This repository is currently named `ECMA-xxx-PURL` as a placeholder. Upon ratification of the PURL specification as an Ecma International standard, the repository will be renamed to **`ECMA-xxx`**, where `xxx` represents the number assigned by Ecma to the standard.
+This repository is named `ECMA-xxx-TEA` as a placeholder. Upon ratification of
+the specification as an Ecma International standard, it will be renamed to
+**`ECMA-xxx`**, where `xxx` is the number assigned by Ecma.
+
+## How this specification is built
+
+The normative source material is **not** authored in this repository. It lives
+in the OWASP/CycloneDX TEA source repository:
+
+> <https://github.com/CycloneDX/transparency-exchange-api>
+
+Two sources of truth are pulled from there at build time:
+
+- `spec/openapi.yaml` — the API surface and data model are generated from it.
+- The narrative Markdown files (discovery, authentication, use cases, the TEA
+  object model, signatures, …) — imported verbatim as specification prose.
+
+This repository owns the **publication pipeline**: it converts those sources
+into an [Ecmarkup](https://github.com/tc39/ecmarkup) document and renders it to
+HTML and PDF using the same toolchain TC54 already uses for ECMA-424.
+
+```
+CycloneDX/transparency-exchange-api  (Markdown + OpenAPI)
+        │  fetched by index.js
+        ▼
+   spec.html  (generated Ecmarkup source, committed)
+        │  ecmarkup
+        ▼
+   out/  (single-page + multipage HTML)
+        │  PrinceXML (ghcr.io/ecma-tc54/princexml in CI)
+        ▼
+   out/spec.pdf
+```
+
+### Layout
+
+| Path | Purpose |
+|---|---|
+| `index.js` | Fetches TEA sources and assembles `spec.html`. |
+| `lib/md-to-emu.js` | Markdown → nested `<emu-clause>` conversion. |
+| `lib/openapi-to-emu.js` | OpenAPI → API-surface and data-model clauses. |
+| `excerpts/` | Hand-authored front/back matter (header, scope, conformance, references, terms, bibliography, colophon). |
+| `spec.html` | Generated Ecmarkup source, committed for reviewer diff-ability. |
+
+## Building locally
+
+```bash
+npm ci                 # install (PUPPETEER_SKIP_DOWNLOAD=true is fine)
+npm run generate-spec  # fetch TEA sources -> spec.html
+npm run build          # spec.html -> out/ (single + multipage HTML, lint-spec)
+npm run build-for-pdf  # spec.html -> out/index.html with external assets (PDF input)
+```
+
+To render a PDF locally you need [PrinceXML](https://www.princexml.com/):
+
+```bash
+prince-books --script ./node_modules/ecmarkup/js/print.js out/index.html -o out/spec.pdf
+```
+
+CI runs the licensed `ghcr.io/ecma-tc54/princexml` container to produce a
+watermark-free PDF (see `.github/workflows/build.yml`).
 
 ## Contributing
 
-Contributions to this specification are managed by TC54. If you are part of the TC54 community or have been invited to collaborate, please follow the contribution guidelines outlined in this repository.
+- **Narrative or API changes** belong upstream in
+  [CycloneDX/transparency-exchange-api](https://github.com/CycloneDX/transparency-exchange-api).
+- **Front/back matter, build tooling, and publication concerns** belong here.
 
-For general inquiries or feedback, you may contact Ecma International or TC54 through the official Ecma channels.
-
-## License
-
-This work is licensed under the terms defined by Ecma International, ensuring free access and adoption of the finalised specification.
-
-## Acknowledgements
-
-We thank Ecma International’s TC39 for their development of **Ecmarkup**, which TC54 has successfully adopted for preparing and maintaining this specification.
+Contributions are managed by TC54. We thank Ecma's TC39 for **Ecmarkup**, which
+TC54 has adopted for preparing and maintaining this specification.

--- a/excerpts/0x00-header.html
+++ b/excerpts/0x00-header.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en-GB-oxendict">
+<meta charset="utf-8">
+<link rel="icon" href="img/favicon.ico">
+<style>
+  #metadata-block {
+    margin: 4em 0;
+    padding: 10px;
+    border: 1px solid #ee8421;
+  }
+  #metadata-block h1 {
+    font-size: 1.5em;
+    margin-top: 0;
+  }
+  #metadata-block > ul {
+    list-style-type: none;
+    margin: 0; padding: 0;
+  }
+
+  #ecma-logo {
+    width: 500px;
+  }
+
+  @page {
+    @prince-overlay {
+      color: rgba(0,0,0,0.15);
+      content: "DRAFT";
+      font-family: Arial;
+      font-weight: bolder;
+      font-size: 200pt;
+      transform: rotate(-60deg);
+    }
+  }
+
+  figure pre {
+    margin-top: 0;
+    margin-bottom: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  code.pattern { font-weight: normal !important; }
+  .tea-method {
+    display: inline-block;
+    padding: 0.05em 0.4em;
+    border-radius: 0.25em;
+    font-weight: bold;
+    background: #eef;
+    margin-right: 0.4em;
+  }
+  .tea-path { font-family: monospace; }
+</style>
+<pre class="metadata">
+  title: Transparency Exchange API Specification
+  shortname: ECMA-xxx
+  status: draft
+  location: https://tc54.org/ecmaXXX/
+  markEffects: true
+</pre>
+<p><img src="img/ecma-logo.svg" id="ecma-logo" alt="Ecma International logo"></p>
+<div id="metadata-block">
+  <h1>About this Specification</h1>
+  <p>The document at <a href="https://tc54.org/ecmaXXX/">https://tc54.org/ecmaXXX/</a> is the most accurate and up-to-date Transparency Exchange API specification.</p>
+  <p>This document is available as <a href>a single page</a> and as <a href="multipage/">multiple pages</a>.</p>
+  <h1>Contributing to this Specification</h1>
+  <p>This specification is developed on GitHub with the help of the OWASP community. There are a number of ways to contribute to the development of this specification:</p>
+  <ul>
+    <li>GitHub Repository: <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA">https://github.com/Ecma-TC54/ECMA-xxx-TEA</a></li>
+    <li>Issues: <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA/issues">All Issues</a>, <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA/issues/new">File a New Issue</a></li>
+    <li>Pull Requests: <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA/pulls">All Pull Requests</a>, <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA/pulls/new">Create a New Pull Request</a></li>
+    <li>Source repository (narrative and OpenAPI): <a href="https://github.com/CycloneDX/transparency-exchange-api">https://github.com/CycloneDX/transparency-exchange-api</a></li>
+    <li>
+      Editors:
+      <ul>
+        <li><a href="mailto:oej@edvina.net">Olle E Johansson</a></li>
+        <li><a href="mailto:steve.springett@owasp.org">Steve Springett</a></li>
+      </ul>
+    </li>
+    <li>
+      Community:
+      <ul>
+        <li>Chat: <a href="https://cyclonedx.slack.com/archives/C04LR6R9T8E">Slack Channel</a></li>
+      </ul>
+    </li>
+  </ul>
+  <p>Refer to the <emu-xref href="#sec-colophon">colophon</emu-xref> for more information on how this document is created.</p>
+</div>

--- a/excerpts/0x20-scope.html
+++ b/excerpts/0x20-scope.html
@@ -1,0 +1,28 @@
+<emu-clause id="sec-scope">
+  <h1>Scope</h1>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <p>
+    This Specification defines the Transparency Exchange API (TEA), a
+    format-agnostic protocol for the exchange of software, hardware and
+    system transparency artefacts &mdash; including, but not limited to,
+    Bills of Materials (xBOMs), attestations, vulnerability disclosure
+    documents, and lifecycle events &mdash; between publishers and
+    consumers.
+  </p>
+  <p>
+    The Specification covers:
+  </p>
+  <ul>
+    <li>The Transparency Exchange Identifier (TEI) and its resolution.</li>
+    <li>The data model used to describe products, components, releases, collections and artefacts.</li>
+    <li>The HTTP API surface used to discover, retrieve and (in future revisions) publish transparency artefacts.</li>
+    <li>Authentication and authorization patterns expected of conformant implementations.</li>
+  </ul>
+  <p>
+    The Specification does <em>not</em> define the internal format of the
+    transparency artefacts themselves; those are defined by their respective
+    standards (e.g. CycloneDX, SPDX, OpenVEX, CSAF, CDXA).
+  </p>
+</emu-clause>

--- a/excerpts/0x21-conformance.html
+++ b/excerpts/0x21-conformance.html
@@ -1,0 +1,20 @@
+<emu-clause id="sec-conformance">
+  <h1>Conformance</h1>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <p>
+    A conformant TEA implementation shall:
+  </p>
+  <ul>
+    <li>Implement the consumer API surface defined in <emu-xref href="#sec-tea-api"></emu-xref> in full.</li>
+    <li>Resolve Transparency Exchange Identifiers per the Discovery chapter.</li>
+    <li>Honour the authentication and authorization model defined in the Authentication chapter.</li>
+    <li>Use the data model defined in <emu-xref href="#sec-tea-data-model"></emu-xref> for request and response payloads.</li>
+  </ul>
+  <p>
+    The terms <strong>shall</strong>, <strong>shall not</strong>, <strong>should</strong>,
+    <strong>should not</strong>, and <strong>may</strong> are to be interpreted as
+    described in IETF RFC 2119 and RFC 8174.
+  </p>
+</emu-clause>

--- a/excerpts/0x22-normative-references.html
+++ b/excerpts/0x22-normative-references.html
@@ -1,0 +1,19 @@
+<emu-clause id="sec-normative-references">
+  <h1>Normative references</h1>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <p>
+    The following referenced documents are indispensable for the application of this Specification.
+  </p>
+  <ul>
+    <li>IETF RFC 2119 &mdash; Key words for use in RFCs to Indicate Requirement Levels.</li>
+    <li>IETF RFC 8174 &mdash; Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words.</li>
+    <li>IETF RFC 8141 &mdash; Uniform Resource Names (URNs).</li>
+    <li>IETF RFC 7519 &mdash; JSON Web Token (JWT).</li>
+    <li>IETF RFC 9457 &mdash; Problem Details for HTTP APIs.</li>
+    <li>OpenAPI Specification, version 3.1.1.</li>
+    <li>ECMA-424 &mdash; CycloneDX Bill of Materials Specification.</li>
+    <li>ECMA-428 &mdash; Common Lifecycle Enumeration (CLE).</li>
+  </ul>
+</emu-clause>

--- a/excerpts/0x23-terms-and-definitions.html
+++ b/excerpts/0x23-terms-and-definitions.html
@@ -1,0 +1,25 @@
+<emu-clause id="sec-terms-and-definitions">
+  <h1>Terms and definitions</h1>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <p>For the purposes of this Specification, the following terms and definitions apply.</p>
+  <dl>
+    <dt>API</dt>
+    <dd>Application Programming Interface.</dd>
+    <dt>Authentication (authn)</dt>
+    <dd>The process of verifying the identity of a principal.</dd>
+    <dt>Authorization (authz)</dt>
+    <dd>The process of determining what a verified principal is permitted to do.</dd>
+    <dt>Collection</dt>
+    <dd>A versioned set of TEA Artifacts associated with a specific TEA Release.</dd>
+    <dt>Product</dt>
+    <dd>An item sold, distributed or otherwise delivered under one name.</dd>
+    <dt>Product Release</dt>
+    <dd>A specific version of a Product that can be acquired or downloaded.</dd>
+    <dt>TEA Artifact</dt>
+    <dd>A named file (e.g. an SBOM, an attestation, a VEX document) referenced by a Collection.</dd>
+    <dt>TEI</dt>
+    <dd>Transparency Exchange Identifier &mdash; a URN that resolves to a TEA Product Release.</dd>
+  </dl>
+</emu-clause>

--- a/excerpts/1x10-bibliography.html
+++ b/excerpts/1x10-bibliography.html
@@ -1,0 +1,14 @@
+<emu-annex id="sec-bibliography">
+  <h1>Bibliography</h1>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <ul>
+    <li>CycloneDX project &mdash; <a href="https://cyclonedx.org/">https://cyclonedx.org/</a>.</li>
+    <li>SPDX project &mdash; <a href="https://spdx.dev/">https://spdx.dev/</a>.</li>
+    <li>OpenVEX project &mdash; <a href="https://openvex.dev/">https://openvex.dev/</a>.</li>
+    <li>OASIS CSAF &mdash; <a href="https://oasis-open.github.io/csaf-documentation/">https://oasis-open.github.io/csaf-documentation/</a>.</li>
+    <li>NTIA Minimum Elements for an SBOM (2021).</li>
+    <li>Executive Order 14028 &mdash; Improving the Nation's Cybersecurity.</li>
+  </ul>
+</emu-annex>

--- a/excerpts/1x20-colophon.html
+++ b/excerpts/1x20-colophon.html
@@ -1,0 +1,14 @@
+<emu-annex id="sec-colophon">
+  <h1>Colophon</h1>
+  <p>
+    This specification is authored on <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA">GitHub</a> in a plaintext source format called <a href="https://github.com/tc39/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMA specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/tc39/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this specification are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>.
+  </p>
+  <p>
+    The body of this Specification is assembled from two sources of truth held in the
+    <a href="https://github.com/CycloneDX/transparency-exchange-api">Transparency Exchange API</a>
+    source repository: the OpenAPI document at <code>spec/openapi.yaml</code>, from which the API surface and data model are generated; and a set of Markdown documents which carry the narrative chapters and are imported verbatim. The build pipeline in this repository fetches both, converts them to Ecmarkup HTML, and renders them via the standard Ecmarkup toolchain.
+  </p>
+  <p>
+    We extend our gratitude to TC39 for their exceptional work in developing Ecmarkup, which has greatly facilitated TC54's successful adoption of this tool for the preparation and maintenance of our technical specifications.
+  </p>
+</emu-annex>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// Assembles spec.html by fetching the TEA source repository (Markdown + OpenAPI)
+// and stitching it together with the hand-authored excerpts/ files.
+//
+// Mirrors the ECMA-424 build model: the spec.html file is committed to the
+// repository as a generated artefact; running `npm run generate-spec`
+// regenerates it from upstream sources.
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import beautify from "js-beautify";
+import MarkdownIt from "markdown-it";
+import { markdownToEmuClauses } from "./lib/md-to-emu.js";
+import { openApiToEmu } from "./lib/openapi-to-emu.js";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+// TODO: pin TEA_SOURCE_REF to a tag or commit SHA before the first ECMA
+// publication build. Tracking `main` is acceptable for working-group review
+// drafts but is not reproducible: re-running the build at a later date may
+// produce different output. See discussion at
+// https://github.com/Ecma-TC54/ECMA-xxx-TEA/pull/<TBD>.
+const TEA_SOURCE_REPO = "CycloneDX/transparency-exchange-api";
+const TEA_SOURCE_REF = "main";
+const RAW_BASE = `https://raw.githubusercontent.com/${TEA_SOURCE_REPO}/${TEA_SOURCE_REF}`;
+
+// Cache fetched TEA sources here so subsequent builds don't re-download.
+const CACHE_DIR = path.join(HERE, "tea-source");
+const OUT_FILE = path.join(HERE, "spec.html");
+
+// Paths inside the TEA source repository, relative to its root.
+const TEA_OPENAPI = "spec/openapi.yaml";
+const TEA_README = "README.md";
+
+// Narrative chapters, in the order they should appear in the spec.
+// Each entry is [pathInTeaRepo, idPrefix]. The idPrefix namespaces clause IDs
+// so unrelated chapters can use the same heading text without collision.
+const NARRATIVE_DOCS = [
+  ["doc/tea-requirements.md", "req"],
+  ["doc/tea-usecases.md", "uc"],
+  ["discovery/readme.md", "discovery"],
+  ["auth/readme.md", "auth"],
+  ["api-flow/consumer.md", "flow-consumer"],
+  ["api-flow/publisher.md", "flow-publisher"],
+  ["tea-product/tea-product.md", "tea-product"],
+  ["tea-product/tea-product-release.md", "tea-product-release"],
+  ["tea-component/tea-component.md", "tea-component"],
+  ["tea-component/tea-release.md", "tea-release"],
+  ["tea-collection/tea-collection.md", "tea-collection"],
+  ["tea-artifact/tea-artifact.md", "tea-artifact"],
+  ["signatures/signature.md", "signatures"],
+];
+
+async function fetchTeaFile(relPath) {
+  const cached = path.join(CACHE_DIR, relPath);
+  if (fs.existsSync(cached)) return fs.readFileSync(cached, "utf-8");
+  const url = `${RAW_BASE}/${relPath}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+  }
+  const text = await res.text();
+  fs.mkdirSync(path.dirname(cached), { recursive: true });
+  fs.writeFileSync(cached, text);
+  return text;
+}
+
+function readExcerpt(name) {
+  return fs.readFileSync(path.join(HERE, "excerpts", name), "utf-8");
+}
+
+async function build() {
+  // Refresh the source cache each run so we pick up upstream changes.
+  if (fs.existsSync(CACHE_DIR)) fs.rmSync(CACHE_DIR, { recursive: true, force: true });
+
+  let html = "";
+
+  html += readExcerpt("0x00-header.html") + "\n";
+
+  const readme = await fetchTeaFile(TEA_README);
+  const introMatch = /## Introduction\n([\s\S]*?)(?=\n## )/.exec(readme);
+  const introMd = introMatch ? introMatch[1].trim() : "";
+  html += `<emu-intro id="sec-intro">\n<h1>Introduction</h1>\n`;
+  if (introMd) {
+    const mdi = new MarkdownIt({ html: true, linkify: true });
+    html += mdi.render(introMd) + "\n";
+  } else {
+    html += "<p>The Transparency Exchange API (TEA) standardises the exchange of supply-chain transparency artefacts.</p>\n";
+  }
+  html += "</emu-intro>\n";
+
+  // Front matter (skeletons authored as excerpts).
+  html += readExcerpt("0x20-scope.html") + "\n";
+  html += readExcerpt("0x21-conformance.html") + "\n";
+  html += readExcerpt("0x22-normative-references.html") + "\n";
+  html += readExcerpt("0x23-terms-and-definitions.html") + "\n";
+
+  // Narrative leads the body of the spec.
+  html += `<emu-clause id="sec-tea-narrative">\n<h1>Specification narrative</h1>\n`;
+  html += "<p>The following sections are derived from the working group's authoring notes maintained as Markdown in the source repository.</p>\n";
+  for (const [rel, idPrefix] of NARRATIVE_DOCS) {
+    let body;
+    try {
+      body = await fetchTeaFile(rel);
+    } catch (err) {
+      console.warn(`skipping ${rel}: ${err.message}`);
+      continue;
+    }
+    html += `<!-- imported from ${TEA_SOURCE_REPO}@${TEA_SOURCE_REF}:${rel} -->\n`;
+    html += markdownToEmuClauses(body, idPrefix);
+  }
+  html += "</emu-clause>\n";
+
+  // Generated API surface + data model follow the narrative.
+  const openapiYaml = await fetchTeaFile(TEA_OPENAPI);
+  html += await openApiToEmu(openapiYaml);
+
+  // Back matter.
+  html += readExcerpt("1x10-bibliography.html") + "\n";
+  html += readExcerpt("1x20-colophon.html") + "\n";
+
+  // js-beautify will mangle <pre>/<code>/<script>. Stash them before pretty-
+  // printing and restore afterwards.
+  const TAGS_TO_SKIP = ["pre", "code", "script"];
+  const placeholders = {};
+  let counter = 0;
+  let working = html;
+  for (const tag of TAGS_TO_SKIP) {
+    const re = new RegExp(`<${tag}[^>]*?>[\\s\\S]*?<\\/${tag}>`, "gi");
+    working = working.replace(re, m => {
+      const k = `__PH_${tag.toUpperCase()}_${counter++}__`;
+      placeholders[k] = m;
+      return k;
+    });
+  }
+  let pretty = beautify.html(working, {
+    indent_size: 2,
+    preserve_newlines: false,
+    max_preserve_newlines: 1,
+    wrap_line_length: 0,
+    end_with_newline: true,
+  });
+  for (const [k, v] of Object.entries(placeholders)) pretty = pretty.replace(k, v);
+
+  fs.writeFileSync(OUT_FILE, pretty);
+  console.log(`wrote ${OUT_FILE} (${pretty.length} bytes)`);
+}
+
+build().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/lib/md-to-emu.js
+++ b/lib/md-to-emu.js
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import MarkdownIt from "markdown-it";
+
+// ecmarkup syntax-highlights fenced blocks via highlight.js. Languages that
+// highlight.js does not recognize (e.g. `mermaid`, `abnf`, `bnf`, `webidl`,
+// `http`, `cmd`, `console`, `text`) crash the build. Strip the language hint
+// for anything we know highlight.js can't handle; render as a plain pre.
+const KNOWN_HLJS_LANGS = new Set([
+  "bash", "cjs", "css", "html", "javascript", "js", "json", "markdown",
+  "mjs", "python", "sh", "shell", "ts", "typescript", "xml", "yaml",
+]);
+
+const md = new MarkdownIt({ html: true, linkify: true });
+
+const defaultFence = md.renderer.rules.fence || ((tokens, idx, options, env, self) => self.renderToken(tokens, idx, options, env));
+md.renderer.rules.fence = function (tokens, idx, options, env, self) {
+  const token = tokens[idx];
+  const info = (token.info || "").trim().split(/\s+/)[0].toLowerCase();
+  if (info && !KNOWN_HLJS_LANGS.has(info)) {
+    token.info = "";
+  }
+  return defaultFence(tokens, idx, options, env, self);
+};
+
+function slugify(text, prefix) {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 80);
+  return `sec-${prefix}${slug ? "-" + slug : ""}`;
+}
+
+function escapeAttr(s) {
+  return s.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+function isLikelyTocLine(line) {
+  // Matches: "- [Some Heading](#some-heading)" optionally with leading indent.
+  return /^\s*[-*]\s+\[[^\]]+\]\(#[^)]+\)\s*$/.test(line);
+}
+
+function stripLeadingToc(source) {
+  const lines = source.split("\n");
+  const out = [];
+  // Skip until first non-TOC, non-blank line. We only strip the leading block
+  // that appears immediately after the H1 (a TOC), to keep authoring intent.
+  let firstHeading = -1;
+  for (let j = 0; j < lines.length; j++) {
+    if (/^#\s+/.test(lines[j])) { firstHeading = j; break; }
+  }
+  if (firstHeading < 0) return source;
+  for (let i = 0; i <= firstHeading; i++) out.push(lines[i]);
+  let k = firstHeading + 1;
+  while (k < lines.length && lines[k].trim() === "") k++;
+  let stripped = false;
+  while (k < lines.length && isLikelyTocLine(lines[k])) {
+    k++;
+    stripped = true;
+  }
+  if (stripped) {
+    while (k < lines.length && lines[k].trim() === "") k++;
+  } else {
+    k = firstHeading + 1;
+  }
+  for (; k < lines.length; k++) out.push(lines[k]);
+  return out.join("\n");
+}
+
+/**
+ * Convert a markdown string into a nested <emu-clause> tree.
+ *
+ * Headings define clause nesting. Levels 1..6 map onto nested clauses.
+ * Content between headings is rendered as HTML via markdown-it.
+ */
+export function markdownToEmuClauses(source, idPrefix) {
+  const stripped = stripLeadingToc(source);
+  const lines = stripped.split("\n");
+
+  const sections = [];
+  const preamble = [];
+  let current = null;
+  for (const line of lines) {
+    const m = /^(#{1,6})\s+(.*?)\s*$/.exec(line);
+    if (m) {
+      if (current) sections.push(current);
+      current = { level: m[1].length, title: m[2].trim(), body: [] };
+    } else if (current) {
+      current.body.push(line);
+    } else {
+      preamble.push(line);
+    }
+  }
+  if (current) sections.push(current);
+
+  let html = "";
+  if (preamble.join("\n").trim()) {
+    html += md.render(preamble.join("\n")) + "\n";
+  }
+
+  const stack = [];
+  let counter = 0;
+
+  const closeTo = (targetLevel) => {
+    while (stack.length && stack[stack.length - 1] >= targetLevel) {
+      html += "</emu-clause>\n";
+      stack.pop();
+    }
+  };
+
+  for (const s of sections) {
+    closeTo(s.level);
+    counter++;
+    const id = slugify(s.title, `${idPrefix}-${counter}`);
+    html += `<emu-clause id="${escapeAttr(id)}">\n`;
+    html += `<h1>${md.renderInline(s.title)}</h1>\n`;
+    const body = s.body.join("\n").trim();
+    if (body) html += md.render(body) + "\n";
+    stack.push(s.level);
+  }
+  closeTo(0);
+  return html;
+}
+
+export function markdownFileToEmuClauses(filePath, idPrefix) {
+  const src = fs.readFileSync(filePath, "utf-8");
+  return markdownToEmuClauses(src, idPrefix);
+}

--- a/lib/md-to-emu.js
+++ b/lib/md-to-emu.js
@@ -113,6 +113,13 @@ export function markdownToEmuClauses(source, idPrefix) {
     counter++;
     const id = slugify(s.title, `${idPrefix}-${counter}`);
     html += `<emu-clause id="${escapeAttr(id)}">\n`;
+    // Narrative headings are emitted verbatim, so titles with parentheses
+    // (e.g. "TEA Collection object (TCO)") reach ecmarkup as clause headers.
+    // ecmarkup's `header-format` lint rule reads "( ... )" as an algorithm
+    // parameter list and flags it. This is why the default `build-head` runs
+    // `--lint-spec` without `--strict` (see package.json). The strict build is
+    // kept as `build-head-strict`; closing these warnings needs either
+    // author-side heading edits upstream or a slug/rewrite pass here.
     html += `<h1>${md.renderInline(s.title)}</h1>\n`;
     const body = s.body.join("\n").trim();
     if (body) html += md.render(body) + "\n";

--- a/lib/openapi-to-emu.js
+++ b/lib/openapi-to-emu.js
@@ -1,0 +1,211 @@
+import yaml from "js-yaml";
+import $RefParser from "@apidevtools/json-schema-ref-parser";
+import MarkdownIt from "markdown-it";
+
+const md = new MarkdownIt({ html: true, linkify: true });
+
+const HTTP_METHODS = ["get", "post", "put", "patch", "delete", "options", "head"];
+
+function esc(s) {
+  if (s === undefined || s === null) return "";
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escAttr(s) {
+  return esc(s).replace(/"/g, "&quot;");
+}
+
+function slug(s) {
+  return String(s).toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+}
+
+function renderDescription(text) {
+  if (!text) return "";
+  return md.render(String(text));
+}
+
+/**
+ * Loads an OpenAPI document with internal $refs resolved (bundled, not
+ * dereferenced — we want to preserve named schema identity for the data-model
+ * section).
+ */
+async function loadOpenApi(yamlText) {
+  const raw = yaml.load(yamlText);
+  // Bundle so $refs inside parameters/responses resolve to inline structures
+  // we can render in place, while leaving named schemas under components.schemas
+  // for the data-model section.
+  return await $RefParser.bundle(raw);
+}
+
+function typeForSchema(schema) {
+  if (!schema) return "—";
+  if (schema.$ref) {
+    const name = schema.$ref.split("/").pop();
+    return `<a href="#sec-tea-schema-${escAttr(slug(name))}"><code>${esc(name)}</code></a>`;
+  }
+  if (schema.type === "array") {
+    const inner = typeForSchema(schema.items);
+    return `Array of ${inner}`;
+  }
+  if (schema.enum) {
+    return `${esc(schema.type || "string")} (enum)`;
+  }
+  return esc(schema.type || (schema.oneOf ? "oneOf" : schema.anyOf ? "anyOf" : "object"));
+}
+
+function renderEnumTable(schema) {
+  if (!schema.enum) return "";
+  let out = "<emu-table><emu-caption>Enumeration of possible values</emu-caption><table>";
+  out += "<thead><tr><th>Value</th></tr></thead><tbody>";
+  for (const v of schema.enum) out += `<tr><td><code>${esc(v)}</code></td></tr>`;
+  out += "</tbody></table></emu-table>\n";
+  return out;
+}
+
+function renderPropertiesTable(schema) {
+  if (!schema.properties) return "";
+  const required = new Set(schema.required || []);
+  let out = "<emu-table><emu-caption>Properties</emu-caption><table>";
+  out += "<thead><tr><th>Property</th><th>Type</th><th>Requirement</th><th>Description</th></tr></thead><tbody>";
+  for (const [name, prop] of Object.entries(schema.properties)) {
+    out += `<tr><td><code>${esc(name)}</code></td>`;
+    out += `<td>${typeForSchema(prop)}</td>`;
+    out += `<td>${required.has(name) ? "Required" : "Optional"}</td>`;
+    out += `<td>${esc(prop.description || "")}</td></tr>`;
+  }
+  out += "</tbody></table></emu-table>\n";
+  return out;
+}
+
+function renderSchemaClause(name, schema, idPrefix = "tea-schema-") {
+  const id = `sec-${idPrefix}${slug(name)}`;
+  let out = `<emu-clause id="${escAttr(id)}">\n<h1>${esc(name)}</h1>\n`;
+  if (schema.description) out += renderDescription(schema.description);
+  if (schema.type) out += `<p><strong>Type:</strong> ${esc(schema.type)}</p>\n`;
+  if (schema.format) out += `<p><strong>Format:</strong> ${esc(schema.format)}</p>\n`;
+  if (schema.pattern) out += `<p><strong>Pattern:</strong> <code class="pattern">${esc(schema.pattern)}</code></p>\n`;
+  if (schema.enum) out += renderEnumTable(schema);
+  if (schema.properties) out += renderPropertiesTable(schema);
+  if (schema.examples || schema.example) {
+    const examples = schema.examples || [schema.example];
+    for (const ex of examples) {
+      out += "<emu-example><pre>" + esc(typeof ex === "string" ? ex : JSON.stringify(ex, null, 2)) + "</pre></emu-example>\n";
+    }
+  }
+  out += "</emu-clause>\n";
+  return out;
+}
+
+function renderOperation(method, pathStr, op) {
+  const opIdSlug = slug(op.operationId || `${method}-${pathStr}`);
+  const id = `sec-tea-op-${opIdSlug}`;
+  let out = `<emu-clause id="${escAttr(id)}">\n`;
+  out += `<h1>${esc(op.summary || op.operationId || `${method.toUpperCase()} ${pathStr}`)}</h1>\n`;
+  out += `<p><span class="tea-method">${method.toUpperCase()}</span><code class="tea-path">${esc(pathStr)}</code></p>\n`;
+  if (op.description) out += renderDescription(op.description);
+
+  if (op.parameters && op.parameters.length > 0) {
+    out += "<emu-table><emu-caption>Parameters</emu-caption><table>";
+    out += "<thead><tr><th>Name</th><th>In</th><th>Required</th><th>Type</th><th>Description</th></tr></thead><tbody>";
+    for (const p of op.parameters) {
+      out += `<tr><td><code>${esc(p.name)}</code></td>`;
+      out += `<td>${esc(p.in)}</td>`;
+      out += `<td>${p.required ? "Yes" : "No"}</td>`;
+      out += `<td>${typeForSchema(p.schema)}</td>`;
+      out += `<td>${esc(p.description || "")}</td></tr>`;
+    }
+    out += "</tbody></table></emu-table>\n";
+  }
+
+  if (op.requestBody) {
+    out += "<p><strong>Request body:</strong></p>";
+    const contents = op.requestBody.content || {};
+    for (const [mime, mediaType] of Object.entries(contents)) {
+      out += `<p><code>${esc(mime)}</code> &mdash; ${typeForSchema(mediaType.schema)}`;
+      if (op.requestBody.required) out += " (required)";
+      out += "</p>";
+    }
+  }
+
+  if (op.responses) {
+    out += "<emu-table><emu-caption>Responses</emu-caption><table>";
+    out += "<thead><tr><th>Status</th><th>Description</th><th>Schema</th></tr></thead><tbody>";
+    for (const [status, resp] of Object.entries(op.responses)) {
+      const contents = resp.content || {};
+      const schemas = Object.values(contents).map(c => typeForSchema(c.schema)).join(", ") || "—";
+      out += `<tr><td><code>${esc(status)}</code></td>`;
+      out += `<td>${esc(resp.description || "")}</td>`;
+      out += `<td>${schemas}</td></tr>`;
+    }
+    out += "</tbody></table></emu-table>\n";
+  }
+
+  out += "</emu-clause>\n";
+  return out;
+}
+
+/**
+ * Produce the API-surface section: paths grouped by tag, plus a data-model
+ * section listing components.schemas. Wraps the whole thing in a single
+ * top-level <emu-clause id="sec-tea-api">.
+ */
+export async function openApiToEmu(yamlText) {
+  const doc = await loadOpenApi(yamlText);
+
+  let out = "";
+  out += `<emu-clause id="sec-tea-api">\n<h1>The TEA API</h1>\n`;
+  if (doc.info && doc.info.description && doc.info.description !== "TBC") {
+    out += renderDescription(doc.info.description);
+  }
+
+  const byTag = new Map();
+  const untagged = [];
+  for (const [pathStr, pathItem] of Object.entries(doc.paths || {})) {
+    for (const m of HTTP_METHODS) {
+      const op = pathItem[m];
+      if (!op) continue;
+      const tags = op.tags && op.tags.length ? op.tags : null;
+      if (tags) {
+        for (const t of tags) {
+          if (!byTag.has(t)) byTag.set(t, []);
+          byTag.get(t).push({ method: m, path: pathStr, op });
+        }
+      } else {
+        untagged.push({ method: m, path: pathStr, op });
+      }
+    }
+  }
+
+  const tagOrder = Array.from(byTag.keys()).sort();
+  for (const tag of tagOrder) {
+    out += `<emu-clause id="sec-tea-api-${escAttr(slug(tag))}">\n`;
+    out += `<h1>${esc(tag)}</h1>\n`;
+    for (const { method, path, op } of byTag.get(tag)) {
+      out += renderOperation(method, path, op);
+    }
+    out += "</emu-clause>\n";
+  }
+  if (untagged.length) {
+    out += `<emu-clause id="sec-tea-api-untagged">\n<h1>Other operations</h1>\n`;
+    for (const { method, path, op } of untagged) out += renderOperation(method, path, op);
+    out += "</emu-clause>\n";
+  }
+
+  out += "</emu-clause>\n";
+
+  const schemas = (doc.components && doc.components.schemas) || {};
+  if (Object.keys(schemas).length) {
+    out += `<emu-clause id="sec-tea-data-model">\n<h1>Data model</h1>\n`;
+    out += `<p>This section catalogues the named schemas declared in <code>components.schemas</code>.</p>\n`;
+    const names = Object.keys(schemas).sort();
+    for (const name of names) {
+      out += renderSchemaClause(name, schemas[name]);
+    }
+    out += "</emu-clause>\n";
+  }
+
+  return out;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,13 @@
     "": {
       "name": "transparency-exchange-api-specification",
       "version": "1.0.0-SNAPSHOT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.7.0",
+        "js-beautify": "^1.15.4",
+        "js-yaml": "^4.1.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^9.2.0"
+      },
       "devDependencies": {
         "ecmarkup": "21.3.1",
         "glob": "^7.1.6",
@@ -17,14 +24,28 @@
         "tiny-json-http": "^7.1.2"
       }
     },
-    "node_modules/@asamuzakjp/css-color": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.1.1.tgz",
-      "integrity": "sha512-hpRD68SV2OMcZCsrbdkccTw5FXjNDLo5OuqSHyHZfwweGsDWZwDJ2+gONyNAbazZclobMirACLw0lk8WVxIqxA==",
-      "dev": true,
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^2.1.2",
-        "@csstools/css-color-parser": "^3.0.8",
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
         "@csstools/css-parser-algorithms": "^3.0.4",
         "@csstools/css-tokenizer": "^3.0.3",
         "lru-cache": "^10.4.3"
@@ -32,33 +53,29 @@
     },
     "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
       "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/highlight": "^7.10.4"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.29.7",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
       "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.25.9.tgz",
-      "integrity": "sha512-llL88JShoCsth8fF8R4SJnIn+WLvR6ccFxu1H3FlMhDontdcmZWf2HgIZ7AIqV3Xcck1idlohrN4EUBQz6klbw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.25.9",
         "chalk": "^2.4.2",
@@ -71,9 +88,8 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -83,9 +99,8 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -97,33 +112,29 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -133,37 +144,23 @@
     },
     "node_modules/@babel/polyfill": {
       "version": "7.12.1",
-      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-      "integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-      "deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "core-js": "^2.6.5",
         "regenerator-runtime": "^0.13.4"
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.29.7",
       "dev": true,
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "dev": true
-    },
     "node_modules/@csstools/color-helpers": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "version": "5.1.0",
       "dev": true,
       "funding": [
         {
@@ -175,14 +172,13 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT-0",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.2.tgz",
-      "integrity": "sha512-TklMyb3uBB28b5uQdxjReG4L80NxAqgrECqLZFQbyLekwwlcDDS8r3f07DKqeo8C4926Br0gf/ZDe17Zv4wIuw==",
+      "version": "2.1.4",
       "dev": true,
       "funding": [
         {
@@ -194,18 +190,17 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.8.tgz",
-      "integrity": "sha512-pdwotQjCCnRPuNi06jFuP68cykU1f3ZWExLe/8MQ1LOs8Xq+fTkYgd+2V8mWUWMrOn9iS2HftPVaMZDaXzGbhQ==",
+      "version": "3.1.0",
       "dev": true,
       "funding": [
         {
@@ -217,22 +212,21 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^5.0.2",
-        "@csstools/css-calc": "^2.1.2"
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^3.0.4",
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.4.tgz",
-      "integrity": "sha512-Up7rBoV77rv29d3uKHUIVubz1BTcgyUK72IvCQAbfbMv584xHcGKCKbWh7i8hPrRJ7qU4Y8IO3IY9m+iTB7P3A==",
+      "version": "3.0.5",
       "dev": true,
       "funding": [
         {
@@ -244,17 +238,16 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^3.0.3"
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.3.tgz",
-      "integrity": "sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==",
+      "version": "3.0.4",
       "dev": true,
       "funding": [
         {
@@ -266,15 +259,15 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@esfx/async-canceltoken": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@esfx/async-canceltoken/-/async-canceltoken-1.0.0.tgz",
-      "integrity": "sha512-3Ps/4NPd7qFltmHL+CYXCjZtNXcQGV9BZmpzu8Rt3/0SZMtbQve0gtX0uJDJGvAWa6w3IB4HrKVP12VPoFONmA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@esfx/cancelable": "^1.0.0",
         "@esfx/canceltoken": "^1.0.0",
@@ -284,18 +277,16 @@
     },
     "node_modules/@esfx/cancelable": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@esfx/cancelable/-/cancelable-1.0.0.tgz",
-      "integrity": "sha512-2dry/TuOT9ydpw86f396v09cyi/gLeGPIZSH4Gx+V/qKQaS/OXCRurCY+Cn8zkBfTAgFsjk9NE15d+LPo2kt9A==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@esfx/disposable": "^1.0.0"
       }
     },
     "node_modules/@esfx/canceltoken": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@esfx/canceltoken/-/canceltoken-1.0.0.tgz",
-      "integrity": "sha512-/TgdzC5O89w5v0TgwE2wcdtampWNAFOxzurCtb4RxYVr3m72yk3Bg82vMdznx+H9nnf28zVDR0PtpZO9FxmOkw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@esfx/cancelable": "^1.0.0",
         "@esfx/disposable": "^1.0.0",
@@ -304,15 +295,76 @@
     },
     "node_modules/@esfx/disposable": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@esfx/disposable/-/disposable-1.0.0.tgz",
-      "integrity": "sha512-hu7EI+YxlEWEKrb2himbS13HNaq5mlUePASf99KeQqkiNeqiAZbKqG4w59uDcLZs8JrV3qJqS/NYib5ZMhbfTQ==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -323,18 +375,16 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -343,29 +393,38 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "license": "MIT"
+    },
     "node_modules/@pdf-lib/standard-fonts": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
-      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pako": "^1.0.6"
       }
     },
     "node_modules/@pdf-lib/upng": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
-      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pako": "^1.0.10"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
-      "integrity": "sha512-x4BEjr2SjOPowNeiguzjozQbsc6h437ovD/wu+JpaenxVLm3jkgzHY2xOslMTp50HoTvQreMjiexiGQw1sqZlQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.4",
         "extract-zip": "2.0.1",
@@ -392,9 +451,8 @@
     },
     "node_modules/@puppeteer/browsers/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -409,31 +467,50 @@
     },
     "node_modules/@puppeteer/browsers/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/node": {
-      "version": "22.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.1.tgz",
-      "integrity": "sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==",
+      "version": "25.9.1",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@types/node": "*"
@@ -441,16 +518,20 @@
     },
     "node_modules/abab": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
-      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
-      "deprecated": "Use your platform's native atob() and btoa() methods instead",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/accepts": {
       "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
-      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
@@ -461,9 +542,8 @@
     },
     "node_modules/acorn": {
       "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -473,9 +553,8 @@
     },
     "node_modules/acorn-globals": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.4.tgz",
-      "integrity": "sha512-clfQEh21R+D0leSbUdWf3OcfqyaCSAQ8Ryq00bofSekfr9W8u1jyYZo6ir0xu9Gtcf7BjcHJpnbZH7JOCpP60A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^6.0.1",
         "acorn-walk": "^6.0.1"
@@ -483,9 +562,8 @@
     },
     "node_modules/acorn-globals/node_modules/acorn": {
       "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-      "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -495,53 +573,24 @@
     },
     "node_modules/acorn-walk": {
       "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
-      "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "version": "7.1.4",
       "dev": true,
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
-    "node_modules/agent-base/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/agent-base/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
-    },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -554,10 +603,8 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
-      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
+      "version": "6.2.2",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -567,9 +614,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -581,61 +626,50 @@
       }
     },
     "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "license": "Python-2.0"
     },
     "node_modules/array-back": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-3.1.0.tgz",
-      "integrity": "sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/array-equal": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.2.tgz",
-      "integrity": "sha512-gUHx76KtnhEgB3HOuFYiCm3FIdEs6ocM2asHvNTkfu/Y09qQVrrVVaOKENmS2KkSaGoxgXNqC+ZVtR/n0MOkSA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/array-flatten": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asn1": {
       "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": "~2.1.0"
       }
     },
     "node_modules/assert-plus": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
-      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -645,149 +679,126 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/aws4": {
       "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
-      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/b4a": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
-      "dev": true
+      "version": "1.8.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
-      "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
+      "version": "2.9.1",
       "dev": true,
-      "optional": true
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-      "dev": true,
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
-    },
-    "node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/browser-process-hrtime": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz",
-      "integrity": "sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==",
-      "dev": true
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "dev": true,
       "funding": [
         {
@@ -803,6 +814,100 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT"
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bl": {
+      "version": "5.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browser-process-hrtime": {
+      "version": "1.0.0",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
@@ -810,46 +915,24 @@
     },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
-      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
-    "node_modules/call-bind": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
-      "dev": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -858,26 +941,38 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/caseless": {
       "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -891,9 +986,8 @@
     },
     "node_modules/chromium-bidi": {
       "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-0.4.16.tgz",
-      "integrity": "sha512-7ZbXdWERxRxSwo3txsBjjmc/NLxqb1Bk30mRb0BMS4YIaiV6zvKZqL/UAH+DdqcDYayDWk2n/y8klkBDODrPvA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "mitt": "3.0.0"
       },
@@ -903,15 +997,13 @@
     },
     "node_modules/clear-cut": {
       "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/clear-cut/-/clear-cut-2.0.2.tgz",
-      "integrity": "sha512-WVgn/gSejQ+0aoR8ucbKIdo6icduPZW6AbWwyUmAUgxy63rUYjwa5rj/HeoNPhf0/XPrl82X8bO/hwBkSmsFtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
-      "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
@@ -924,9 +1016,8 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -936,9 +1027,8 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -950,18 +1040,16 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -971,18 +1059,15 @@
     },
     "node_modules/clone": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -992,15 +1077,12 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1010,9 +1092,8 @@
     },
     "node_modules/command-line-args": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.2.1.tgz",
-      "integrity": "sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^3.1.0",
         "find-replace": "^3.0.0",
@@ -1025,9 +1106,8 @@
     },
     "node_modules/command-line-usage": {
       "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.3.tgz",
-      "integrity": "sha512-sH5ZSPr+7UStsloltmDh7Ce5fb8XPlHyoPzTpyyMuYCtervL65+ubVZ6Q61cFtFl62UyJlc8/JwERRbAFPUqgw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^4.0.2",
         "chalk": "^2.4.2",
@@ -1040,9 +1120,8 @@
     },
     "node_modules/command-line-usage/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -1052,18 +1131,16 @@
     },
     "node_modules/command-line-usage/node_modules/array-back": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/command-line-usage/node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1075,33 +1152,29 @@
     },
     "node_modules/command-line-usage/node_modules/color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/command-line-usage/node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/command-line-usage/node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/command-line-usage/node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -1111,33 +1184,36 @@
     },
     "node_modules/command-line-usage/node_modules/typical": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/commander": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
-      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
-      "dev": true,
+      "version": "10.0.1",
+      "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=14"
       }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "license": "MIT",
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
-      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -1147,47 +1223,40 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
-      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
-      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "version": "0.7.2",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
-      "dev": true
+      "version": "1.0.7",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/core-js": {
       "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
-      "hasInstallScript": true
+      "hasInstallScript": true,
+      "license": "MIT"
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cosmiconfig": {
       "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.2.0.tgz",
-      "integrity": "sha512-3rTMnFJA1tCOPwRxtgF4wd7Ab2qvDbL8jX+3smjIbS4HlZBagTlpERbdN7iAbWlrfxE3M8c27kTwTawQ7st+OQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "import-fresh": "^3.2.1",
         "js-yaml": "^4.1.0",
@@ -1201,38 +1270,18 @@
         "url": "https://github.com/sponsors/d-fischer"
       }
     },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/cross-fetch": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
-      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-fetch/node_modules/node-fetch": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1250,31 +1299,39 @@
     },
     "node_modules/cross-fetch/node_modules/tr46": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/cross-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css-tree": {
       "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
-      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.14",
         "source-map": "^0.6.1"
@@ -1285,15 +1342,13 @@
     },
     "node_modules/cssom": {
       "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
-      "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cssstyle": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cssom": "~0.3.6"
       },
@@ -1303,15 +1358,13 @@
     },
     "node_modules/cssstyle/node_modules/cssom": {
       "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/d": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
-      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "es5-ext": "^0.10.64",
         "type": "^2.7.2"
@@ -1322,9 +1375,8 @@
     },
     "node_modules/dashdash": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       },
@@ -1334,18 +1386,16 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/data-urls": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
-      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abab": "^2.0.0",
         "whatwg-mimetype": "^2.2.0",
@@ -1354,45 +1404,39 @@
     },
     "node_modules/debug": {
       "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
-      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==",
-      "dev": true
+      "version": "10.6.0",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dedent-js": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dedent-js/-/dedent-js-1.0.1.tgz",
-      "integrity": "sha512-OUepMozQULMLUmhxS95Vudo0jb0UchLimi3+pQ2plj61Fcy8axbP9hbiD4Sz6DPqn6XG3kfmziVfQ1rSys5AJQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/defaults": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
       },
@@ -1400,28 +1444,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/define-data-property": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
-      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
-      "dev": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/degenerator": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
-      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -1433,9 +1459,8 @@
     },
     "node_modules/degenerator/node_modules/escodegen": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
-      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -1454,36 +1479,32 @@
     },
     "node_modules/degenerator/node_modules/estraverse": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
-      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/destroy": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
-      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
@@ -1491,25 +1512,21 @@
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1147663",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1147663.tgz",
-      "integrity": "sha512-hyWmRrexdhbZ1tcJUGpO95ivbRhWXz++F4Ko+n21AY5PNln2ovoJw+8ZMNDTtip+CNFQfrtLVh/w4009dXO/eQ==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/domexception": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
-      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
-      "deprecated": "Use your platform's native DOMException instead",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "webidl-conversions": "^4.0.2"
       }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1519,36 +1536,31 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "license": "MIT"
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
       }
     },
-    "node_modules/ecc-jsbn/node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
-    },
     "node_modules/ecmarkdown": {
       "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/ecmarkdown/-/ecmarkdown-8.1.0.tgz",
-      "integrity": "sha512-dx6cM6RFjzAXkWr2KQRikED4gy70NFQ0vTI4XUQM/LWcjUYRJUbGdd7nd++trXi5az1JSe49TeeCIVMKDXOtcQ==",
       "dev": true,
+      "license": "WTFPL",
       "dependencies": {
         "escape-html": "^1.0.1"
       }
     },
     "node_modules/ecmarkup": {
       "version": "21.3.1",
-      "resolved": "https://registry.npmjs.org/ecmarkup/-/ecmarkup-21.3.1.tgz",
-      "integrity": "sha512-G2ZfUg6XGr3qehTezStjlOjV912nMYPu22LoTgx/JejfFutmu/7Si/hMeq2s4EELl1y3B6o1403vXC4ihdR3/A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "command-line-args": "^5.2.0",
@@ -1575,13 +1587,20 @@
         "node": ">= 18"
       }
     },
-    "node_modules/ecmarkup/node_modules/cssstyle": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.3.0.tgz",
-      "integrity": "sha512-6r0NiY0xizYqfBvWp1G7WXJ06/bZyrk7Dc6PHql82C/pKGUTKu4yAX4Y8JPamb1ob9nBKuxWzCGTRuGwU3yxJQ==",
+    "node_modules/ecmarkup/node_modules/argparse": {
+      "version": "1.0.10",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^3.1.1",
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/cssstyle": {
+      "version": "4.6.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
         "rrweb-cssom": "^0.8.0"
       },
       "engines": {
@@ -1590,15 +1609,13 @@
     },
     "node_modules/ecmarkup/node_modules/cssstyle/node_modules/rrweb-cssom": {
       "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecmarkup/node_modules/data-urls": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
         "whatwg-url": "^14.0.0"
@@ -1607,15 +1624,26 @@
         "node": ">=18"
       }
     },
-    "node_modules/ecmarkup/node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+    "node_modules/ecmarkup/node_modules/entities": {
+      "version": "6.0.1",
       "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/ecmarkup/node_modules/form-data": {
+      "version": "4.0.5",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -1624,9 +1652,8 @@
     },
     "node_modules/ecmarkup/node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
       },
@@ -1636,9 +1663,8 @@
     },
     "node_modules/ecmarkup/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -1646,11 +1672,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ecmarkup/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/ecmarkup/node_modules/jsdom": {
       "version": "25.0.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
-      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -1687,18 +1724,16 @@
       }
     },
     "node_modules/ecmarkup/node_modules/jsdom/node_modules/nwsapi": {
-      "version": "2.2.18",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.18.tgz",
-      "integrity": "sha512-p1TRH/edngVEHVbwqWnxUViEmq5znDvyB+Sik5cmuLpGOIfDf/39zLiq3swPF8Vakqn+gvNiOQAZu8djYlQILA==",
-      "dev": true
+      "version": "2.2.23",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ecmarkup/node_modules/jsdom/node_modules/parse5": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-      "integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+      "version": "7.3.0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "entities": "^4.5.0"
+        "entities": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -1706,9 +1741,8 @@
     },
     "node_modules/ecmarkup/node_modules/saxes": {
       "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
-      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -1718,9 +1752,8 @@
     },
     "node_modules/ecmarkup/node_modules/tough-cookie": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
       },
@@ -1729,10 +1762,9 @@
       }
     },
     "node_modules/ecmarkup/node_modules/tr46": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
-      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "version": "5.1.1",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -1742,9 +1774,8 @@
     },
     "node_modules/ecmarkup/node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
-      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -1754,18 +1785,16 @@
     },
     "node_modules/ecmarkup/node_modules/webidl-conversions": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/ecmarkup/node_modules/whatwg-encoding": {
       "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -1775,20 +1804,18 @@
     },
     "node_modules/ecmarkup/node_modules/whatwg-mimetype": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/ecmarkup/node_modules/whatwg-url": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.1.1.tgz",
-      "integrity": "sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==",
+      "version": "14.2.0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tr46": "^5.0.0",
+        "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
       },
       "engines": {
@@ -1796,10 +1823,9 @@
       }
     },
     "node_modules/ecmarkup/node_modules/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "version": "8.21.0",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -1818,48 +1844,76 @@
     },
     "node_modules/ecmarkup/node_modules/xml-name-validator": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
-      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/editorconfig": {
+      "version": "1.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "^9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.9",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
-      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "version": "1.4.5",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
       "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-      "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -1868,37 +1922,33 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1908,9 +1958,8 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -1923,10 +1972,9 @@
     },
     "node_modules/es5-ext": {
       "version": "0.10.64",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
-      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "ISC",
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -1939,9 +1987,8 @@
     },
     "node_modules/es6-iterator": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -1950,9 +1997,8 @@
     },
     "node_modules/es6-symbol": {
       "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
-      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.2",
         "ext": "^1.7.0"
@@ -1963,33 +2009,29 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
-      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/escodegen": {
       "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.3.tgz",
-      "integrity": "sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
@@ -2008,23 +2050,24 @@
       }
     },
     "node_modules/eslint-formatter-codeframe": {
-      "version": "7.32.1",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-codeframe/-/eslint-formatter-codeframe-7.32.1.tgz",
-      "integrity": "sha512-DK/3Q3+zVKq/7PdSYiCxPrsDF8H/TRMK5n8Hziwr4IMkMy+XiKSwbpj25AdajS63I/B61Snetq4uVvX9fOLyAg==",
+      "version": "7.32.2",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "chalk": "^4.0.0"
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/esniff": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
-      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -2037,9 +2080,8 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -2050,103 +2092,107 @@
     },
     "node_modules/estraverse": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
     },
     "node_modules/esutils": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/event-emitter": {
       "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
       }
     },
-    "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+    "node_modules/events-universal": {
+      "version": "1.0.1",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.7.1",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ext": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
-      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "type": "^2.7.2"
       }
     },
     "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -2163,10 +2209,9 @@
       }
     },
     "node_modules/extract-zip/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2181,42 +2226,37 @@
     },
     "node_modules/extract-zip/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extsprintf": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
-      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "version": "3.3.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -2224,38 +2264,32 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fastq": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-      "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+      "version": "1.20.1",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
       }
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
       }
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
       "dev": true,
       "funding": [
         {
@@ -2267,6 +2301,7 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -2277,9 +2312,8 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2288,17 +2322,16 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
-      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "version": "1.3.2",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.2",
         "unpipe": "~1.0.0"
       },
       "engines": {
@@ -2307,9 +2340,8 @@
     },
     "node_modules/find-replace": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-3.0.0.tgz",
-      "integrity": "sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^3.0.1"
       },
@@ -2317,20 +2349,42 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forever-agent": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/form-data": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -2342,9 +2396,8 @@
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -2354,57 +2407,50 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
-      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
       "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2426,9 +2472,8 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2439,9 +2484,8 @@
     },
     "node_modules/get-stream": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -2453,10 +2497,9 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.4.tgz",
-      "integrity": "sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==",
+      "version": "6.0.5",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -2468,18 +2511,16 @@
     },
     "node_modules/get-uri/node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
-      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/get-uri/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2494,25 +2535,21 @@
     },
     "node_modules/get-uri/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/getpass": {
       "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
       "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2530,9 +2567,8 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2542,9 +2578,8 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2554,9 +2589,8 @@
     },
     "node_modules/grammarkdown": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/grammarkdown/-/grammarkdown-3.3.2.tgz",
-      "integrity": "sha512-inNbeEotDr7MENqoZlms3x4gBzvK73wR2NGpNVnw4oEZcsq2METUbAh0J3VWtEqd9t2+U3poEqiJ9CDgBXr5Tg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@esfx/async-canceltoken": "^1.0.0-pre.13",
         "@esfx/cancelable": "^1.0.0-pre.13",
@@ -2568,19 +2602,16 @@
     },
     "node_modules/har-schema": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/har-validator": {
       "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
@@ -2591,30 +2622,16 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
-      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
-      "dev": true,
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2624,9 +2641,8 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -2638,10 +2654,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2651,26 +2666,22 @@
     },
     "node_modules/highlight.js": {
       "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.0.1.tgz",
-      "integrity": "sha512-EqYpWyTF2s8nMfttfBA2yLKPNoZCO33pLS4MnbXQ4hECf1TKujCt1Kq7QAdrio7roL4+CqsfjqwYj4tYgq0pJQ==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
       }
     },
     "node_modules/html-encoding-sniffer": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^1.0.1"
       }
     },
     "node_modules/html-entities": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
-      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
+      "version": "2.6.0",
       "dev": true,
       "funding": [
         {
@@ -2681,35 +2692,37 @@
           "type": "patreon",
           "url": "https://patreon.com/mdevils"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/html-escape": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/html-escape/-/html-escape-1.0.2.tgz",
-      "integrity": "sha512-r4cqVc7QAX1/jpPsW9OJNsTTtFhcf+ZBqoA3rWOddMg/y+n6ElKfz+IGKbvV2RTeECDzyrQXa2rpo3IFFrANWg==",
-      "dev": true
+      "dev": true,
+      "license": "Public Domain"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -2719,10 +2732,9 @@
       }
     },
     "node_modules/http-proxy-agent/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2737,15 +2749,13 @@
     },
     "node_modules/http-proxy-agent/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-signature": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -2757,12 +2767,11 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -2770,10 +2779,9 @@
       }
     },
     "node_modules/https-proxy-agent/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2788,15 +2796,13 @@
     },
     "node_modules/https-proxy-agent/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -2806,8 +2812,6 @@
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true,
       "funding": [
         {
@@ -2822,13 +2826,13 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "version": "3.3.1",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2842,10 +2846,8 @@
     },
     "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2853,76 +2855,61 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "version": "10.2.0",
       "dev": true,
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "dev": true
-    },
     "node_modules/ip-regex": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-      "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2932,9 +2919,8 @@
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-2.0.0.tgz",
-      "integrity": "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2944,30 +2930,26 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-unicode-supported": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-1.3.0.tgz",
-      "integrity": "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -2975,42 +2957,123 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "license": "ISC"
+    },
     "node_modules/isstream": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-beautify": {
+      "version": "1.15.4",
+      "license": "MIT",
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.4",
+        "glob": "^10.4.2",
+        "js-cookie": "^3.0.5",
+        "nopt": "^7.2.1"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.5.0",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-beautify/node_modules/minimatch": {
+      "version": "9.0.9",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.8",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
+      "version": "4.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "dev": true
+      "version": "0.1.1",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jsdom": {
       "version": "15.2.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
-      "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "abab": "^2.0.0",
         "acorn": "^7.1.0",
@@ -3053,39 +3116,33 @@
     },
     "node_modules/jsdom/node_modules/parse5": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-schema": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "dev": true
+      "dev": true,
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/jsprim": {
       "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -3097,14 +3154,13 @@
       }
     },
     "node_modules/katex": {
-      "version": "0.16.11",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
-      "integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+      "version": "0.16.47",
       "dev": true,
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
       ],
+      "license": "MIT",
       "dependencies": {
         "commander": "^8.3.0"
       },
@@ -3114,18 +3170,16 @@
     },
     "node_modules/katex/node_modules/commander": {
       "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/levn": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -3136,33 +3190,45 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.18.1",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.sortby": {
       "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
-      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-5.1.0.tgz",
-      "integrity": "sha512-l0x2DvrW294C9uDCoQe1VSU4gf529FkSZ6leBl4TiqZH/e+0R7hSfHQBNut2mNygDgHwvYHfFLn6Oxb3VWj2rA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
         "is-unicode-supported": "^1.1.0"
@@ -3175,10 +3241,9 @@
       }
     },
     "node_modules/log-symbols/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.6.2",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3188,75 +3253,103 @@
     },
     "node_modules/lru-cache": {
       "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
-      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "9.2.0",
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/mathjax": {
       "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-3.2.2.tgz",
-      "integrity": "sha512-Bt+SSVU8eBG27zChVewOicYs7Xsdt40qm4+UpHyX7k0/O9NliPc+x77k1/FEsPsjKPZGJvtRZM1vO+geW0OhGw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/mdn-data": {
       "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
-      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
-      "dev": true
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true,
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/methods": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -3267,9 +3360,8 @@
     },
     "node_modules/mime": {
       "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
-      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
@@ -3279,18 +3371,16 @@
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
       "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3300,18 +3390,16 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -3319,52 +3407,51 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
-      "integrity": "sha512-7dX2/10ITVyqh4aOSVI9gdape+t9l2/8QxHrFmUXu4EEUpdlxl6RudZUPZoc+zuY2hk1j7XxVroIVIan/pD/SQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
-      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/next-tick": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
-      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "dev": true,
       "funding": [
         {
@@ -3376,15 +3463,15 @@
           "url": "https://paypal.me/jimmywarting"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -3398,26 +3485,36 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/nwsapi": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/oauth-sign": {
       "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "version": "1.13.4",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -3427,9 +3524,8 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
-      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -3439,18 +3535,16 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/onetime": {
       "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
       },
@@ -3463,9 +3557,8 @@
     },
     "node_modules/optionator": {
       "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
-      "integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.6",
@@ -3480,9 +3573,8 @@
     },
     "node_modules/ora": {
       "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.1.tgz",
-      "integrity": "sha512-ERAyNnZOfqM+Ao3RAvIXkYh5joP220yf59gVe2X/cI6SiCxIdi4c9HZKZD8R6q/RDXEje1THBju6iExiSsgJaQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.0.0",
         "cli-cursor": "^4.0.0",
@@ -3502,10 +3594,9 @@
       }
     },
     "node_modules/ora/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "version": "5.6.2",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
@@ -3514,29 +3605,27 @@
       }
     },
     "node_modules/pac-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-BFi3vZnO9X5Qt6NRz7ZOaPja3ic0PhlsmCRYLOpN11+mWBCR6XJDqW5RF3j8jm4WGGQZtBA+bTfxYzeKW73eHg==",
+      "version": "7.2.0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "get-uri": "^6.0.1",
         "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.5",
+        "https-proxy-agent": "^7.0.6",
         "pac-resolver": "^7.0.1",
-        "socks-proxy-agent": "^8.0.4"
+        "socks-proxy-agent": "^8.0.5"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3551,15 +3640,13 @@
     },
     "node_modules/pac-proxy-agent/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pac-resolver": {
       "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
-      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -3568,11 +3655,14 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pagedjs": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/pagedjs/-/pagedjs-0.4.3.tgz",
-      "integrity": "sha512-YtAN9JAjsQw1142gxEjEAwXvOF5nYQuDwnQ67RW2HZDkMLI+b4RsBE37lULZa9gAr6kDAOGBOhXI4wGMoY3raw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/polyfill": "^7.10.1",
         "@babel/runtime": "^7.21.0",
@@ -3583,9 +3673,8 @@
     },
     "node_modules/pagedjs-cli": {
       "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/pagedjs-cli/-/pagedjs-cli-0.4.3.tgz",
-      "integrity": "sha512-NwmRwLiQAjXBdfG/tUbbv2iA8sZPiXRovTd4YxQRmYpMV1QQufg9Pqni0u6MMFqGxz6W2aZFdxZ5jPjtWrTqXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "commander": "^11.0.0",
         "express": "^4.18.2",
@@ -3604,17 +3693,23 @@
         "pagedjs-cli": "src/cli.js"
       }
     },
+    "node_modules/pagedjs-cli/node_modules/commander": {
+      "version": "11.1.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -3624,9 +3719,8 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -3642,48 +3736,67 @@
     },
     "node_modules/parse5": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "license": "ISC"
+    },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
-      "dev": true
+      "version": "0.1.13",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/pdf-lib": {
       "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
-      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@pdf-lib/standard-fonts": "^1.0.0",
         "@pdf-lib/upng": "^1.0.1",
@@ -3693,33 +3806,28 @@
     },
     "node_modules/pdf-lib/node_modules/tslib": {
       "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/pend": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.6"
       },
@@ -3729,14 +3837,11 @@
     },
     "node_modules/pn": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
-      "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -3744,10 +3849,8 @@
     },
     "node_modules/prex": {
       "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/prex/-/prex-0.4.9.tgz",
-      "integrity": "sha512-pQCB9AH8MXQRBaelDkhnTkqY6GRiXt1xWlx2hBReZYZwVA0m7EQcnF/K55zr87cCADDHmdD+qq7G6a8Pu+BRFA==",
-      "deprecated": "This package has been deprecated in favor of several '@esfx/*' packages that replace it. Please see the README for more information",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@esfx/cancelable": "^1.0.0 || >=1.0.0-pre.13",
         "@esfx/disposable": "^1.0.0 || >=1.0.0-pre.13"
@@ -3755,24 +3858,25 @@
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
     },
     "node_modules/promise-debounce": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-debounce/-/promise-debounce-1.0.1.tgz",
-      "integrity": "sha512-jq3Crngf1DaaOXQIOUkPr7LsW4UsWyn0KW1MJ+yMn5njTJ+F1AuHmjjwJhod9HuoNSSMspSLS9PS3V7BrexwjQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "license": "ISC"
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
-      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -3783,9 +3887,8 @@
     },
     "node_modules/proxy-agent": {
       "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.3.0.tgz",
-      "integrity": "sha512-0LdR757eTj/JfuU7TL2YCuAZnxWXu3tkJbg4Oq3geW/qFNT/32T0sp2HnZ9O0lMR4q3vwAt0+xCA8SR0WAD0og==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -3801,10 +3904,9 @@
       }
     },
     "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3819,21 +3921,18 @@
     },
     "node_modules/proxy-agent/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -3842,10 +3941,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
-      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "version": "3.0.4",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -3853,20 +3951,24 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/puppeteer": {
       "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.9.0.tgz",
-      "integrity": "sha512-kAglT4VZ9fWEGg3oLc4/de+JcONuEJhlh3J6f5R1TLkrY/EHHIHxWXDOzXvaxQCtedmyVXBwg8M+P8YCO/wZjw==",
-      "deprecated": "< 22.8.2 is no longer supported",
       "dev": true,
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "1.4.6",
         "cosmiconfig": "8.2.0",
@@ -3878,9 +3980,8 @@
     },
     "node_modules/puppeteer-core": {
       "version": "20.9.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.9.0.tgz",
-      "integrity": "sha512-H9fYZQzMTRrkboEfPmf7m3CLDN6JvbxXA3qTtS+dFt27tR+CsFHzPsT6pzp6lYL6bJbAPaR0HaPO6uSi+F94Pg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@puppeteer/browsers": "1.4.6",
         "chromium-bidi": "0.4.16",
@@ -3903,9 +4004,8 @@
     },
     "node_modules/puppeteer-core/node_modules/debug": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -3920,15 +4020,13 @@
     },
     "node_modules/puppeteer-core/node_modules/ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/puppeteer-core/node_modules/ws": {
       "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -3946,12 +4044,11 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.2",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -3962,8 +4059,6 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true,
       "funding": [
         {
@@ -3978,33 +4073,26 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
-    },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag==",
-      "dev": true
+      ],
+      "license": "MIT"
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
@@ -4012,9 +4100,8 @@
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4026,34 +4113,29 @@
     },
     "node_modules/reduce-flatten": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
-      "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/regenerator-runtime": {
       "version": "0.13.11",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
-      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/replace-ext": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-2.0.0.tgz",
-      "integrity": "sha512-UszKE5KVK6JvyD92nzMn9cDapSk6w/CaFZ96CnmDMUqH9oowfxF/ZjRITD25H4DnOQClLA4/j7jLGXXLVKxAug==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 10"
       }
     },
     "node_modules/request": {
       "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.8.0",
@@ -4082,9 +4164,8 @@
     },
     "node_modules/request-promise-core": {
       "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-      "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.19"
       },
@@ -4097,10 +4178,8 @@
     },
     "node_modules/request-promise-native": {
       "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-      "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-      "deprecated": "request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "request-promise-core": "1.1.4",
         "stealthy-require": "^1.1.1",
@@ -4115,9 +4194,8 @@
     },
     "node_modules/request-promise-native/node_modules/tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -4127,19 +4205,17 @@
       }
     },
     "node_modules/request/node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
+      "version": "6.5.5",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/request/node_modules/tough-cookie": {
       "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "psl": "^1.1.28",
         "punycode": "^2.1.1"
@@ -4150,27 +4226,24 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/restore-cursor": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
-      "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
@@ -4183,10 +4256,9 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -4194,14 +4266,11 @@
     },
     "node_modules/rrweb-cssom": {
       "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
-      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
       "dev": true,
       "funding": [
         {
@@ -4217,14 +4286,13 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -4239,19 +4307,18 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/saxes": {
       "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
-      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.1.1"
       },
@@ -4259,93 +4326,140 @@
         "node": ">=8"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
-      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "version": "0.19.2",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
         "depd": "2.0.0",
         "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
         "mime": "1.6.0",
         "ms": "2.1.3",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
+        "statuses": "~2.0.2"
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/send/node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
       }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/serve-static": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
-      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "version": "1.16.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.19.0"
+        "send": "~0.19.1"
       },
       "engines": {
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/set-function-length": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
-      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "license": "MIT",
       "dependencies": {
-        "define-data-property": "^1.1.4",
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/setprototypeof": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
-      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
-      "dev": true
-    },
-    "node_modules/side-channel": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
-      "integrity": "sha512-fDW/EZ6Q9RiO8eFG8Hj+7u/oW+XrPTIChwCOM2+th2A6OblDtYYIpve9m+KvI9Z4C9qSEXlaGR6bTEYHReuglA==",
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
         "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.4",
-        "object-inspect": "^1.13.1"
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4356,27 +4470,24 @@
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
+      "version": "2.8.9",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ip-address": "^9.0.5",
+        "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
@@ -4385,12 +4496,11 @@
       }
     },
     "node_modules/socks-proxy-agent": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.4.tgz",
-      "integrity": "sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==",
+      "version": "8.0.5",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.1.1",
+        "agent-base": "^7.1.2",
         "debug": "^4.3.4",
         "socks": "^2.8.3"
       },
@@ -4399,10 +4509,9 @@
       }
     },
     "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
-      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "version": "4.4.3",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -4417,30 +4526,26 @@
     },
     "node_modules/socks-proxy-agent/node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
       "version": "1.18.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-      "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "asn1": "~0.2.3",
         "assert-plus": "^1.0.0",
@@ -4461,26 +4566,18 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sshpk/node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-      "dev": true
-    },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/stdin-discarder": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
-      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bl": "^5.0.0"
       },
@@ -4493,41 +4590,33 @@
     },
     "node_modules/stealthy-require": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha512-ZnWpYnYugiOVEY5GkcuJK1io5V8QmNYChG62gSit9pQVGErXtrKuPC55ITaVSukmMta5qpMU7vqLt2Lnni4f/g==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/streamx": {
-      "version": "2.21.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.21.0.tgz",
-      "integrity": "sha512-Qz6MsDZXJ6ur9u+b+4xCG18TluU7PGlRfXVAAjNiGsFrBUt/ioyLkxbFaKJygoPs+/kW4VyBj0bSj89Qu0IGyg==",
+      "version": "2.26.0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
-        "queue-tick": "^1.0.1",
         "text-decoder": "^1.1.0"
-      },
-      "optionalDependencies": {
-        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -4537,20 +4626,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4559,12 +4674,10 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
-      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
+      "version": "7.2.0",
+      "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^6.2.2"
       },
       "engines": {
         "node": ">=12"
@@ -4573,11 +4686,28 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4587,15 +4717,13 @@
     },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
-      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/table-layout": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.2.tgz",
-      "integrity": "sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "array-back": "^4.0.1",
         "deep-extend": "~0.6.0",
@@ -4608,27 +4736,24 @@
     },
     "node_modules/table-layout/node_modules/array-back": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.2.tgz",
-      "integrity": "sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/table-layout/node_modules/typical": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/tar-fs": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.4.tgz",
-      "integrity": "sha512-5AFQU8b9qLfZCX9zp2duONhPmZv0hGYiBPJsyUdqMjzq/mqVpy/rEUSeHk1+YitmxugaptgBh5oDGU3VsAJq4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "mkdirp-classic": "^0.5.2",
         "pump": "^3.0.0",
@@ -4636,21 +4761,20 @@
       }
     },
     "node_modules/tar-fs/node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "version": "3.2.0",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -4664,9 +4788,8 @@
     },
     "node_modules/tar-stream/node_modules/bl": {
       "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -4675,8 +4798,6 @@
     },
     "node_modules/tar-stream/node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "funding": [
         {
@@ -4692,52 +4813,58 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
     "node_modules/text-decoder": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.1.tgz",
-      "integrity": "sha512-x9v3H/lTKIJKQQe7RPQkLfKAnc9lUTkWDypIQgTzPJAq+5/GCDHonmshfvlsNSj58yyshbIJJDLmU15qNERrXQ==",
-      "dev": true
+      "version": "1.2.7",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
     },
     "node_modules/through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tiny-json-http": {
       "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/tiny-json-http/-/tiny-json-http-7.5.1.tgz",
-      "integrity": "sha512-lB7qkBGpL3HR/8gidBu3MMfgfnDj2mlvK/eYXgSbO06gKphemLKGp/TgRTy/BKVD7nCbgIeCm41lMNayXO1f2w==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/tldts": {
-      "version": "6.1.84",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.84.tgz",
-      "integrity": "sha512-aRGIbCIF3teodtUFAYSdQONVmDRy21REM3o6JnqWn5ZkQBJJ4gHxhw6OfwQ+WkSAi3ASamrS4N4nyazWx6uTYg==",
+      "version": "6.1.86",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.84"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.84",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.84.tgz",
-      "integrity": "sha512-NaQa1W76W2aCGjXybvnMYzGSM4x8fvG2AN/pla7qxcg0ZHbooOPhA8kctmOZUDfZyhDL27OGNbwAeig8P4p1vg==",
-      "dev": true
+      "version": "6.1.86",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -4747,18 +4874,16 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
-      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.6"
       }
     },
     "node_modules/tough-cookie": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
-      "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "dependencies": {
         "ip-regex": "^2.1.0",
         "psl": "^1.1.28",
@@ -4770,24 +4895,21 @@
     },
     "node_modules/tr46": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
-      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -4797,21 +4919,18 @@
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-      "dev": true
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type": {
       "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
-      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "prelude-ls": "~1.1.2"
       },
@@ -4821,9 +4940,8 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
@@ -4834,18 +4952,20 @@
     },
     "node_modules/typical": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-4.0.0.tgz",
-      "integrity": "sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "license": "MIT"
+    },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
@@ -4853,8 +4973,6 @@
     },
     "node_modules/unbzip2-stream/node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
       "funding": [
         {
@@ -4870,78 +4988,70 @@
           "url": "https://feross.org/support"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+      "version": "7.24.6",
       "dev": true,
+      "license": "MIT",
       "optional": true
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
       }
     },
     "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/verror": {
       "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "dev": true,
       "engines": [
         "node >=0.6.0"
       ],
+      "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -4950,19 +5060,16 @@
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
-      "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
-      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
       }
     },
     "node_modules/w3c-xmlserializer": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
-      "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "domexception": "^1.0.1",
         "webidl-conversions": "^4.0.2",
@@ -4971,68 +5078,73 @@
     },
     "node_modules/wcwidth": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
       }
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
     },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.4.24"
       }
     },
     "node_modules/whatwg-mimetype": {
       "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-      "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-url": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
-      "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
-      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrapjs": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.1.tgz",
-      "integrity": "sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "reduce-flatten": "^2.0.0",
         "typical": "^5.2.0"
@@ -5043,18 +5155,16 @@
     },
     "node_modules/wordwrapjs/node_modules/typical": {
       "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
-      "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -5067,20 +5177,51 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5090,15 +5231,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.11",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
       },
@@ -5117,30 +5256,26 @@
     },
     "node_modules/xml-name-validator": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
-      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
-      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=10"
       }
     },
     "node_modules/yargs": {
       "version": "17.7.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
-      "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -5156,18 +5291,16 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
     },
     "node_modules/yauzl": {
       "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -2,14 +2,17 @@
   "private": true,
   "name": "transparency-exchange-api-specification",
   "version": "1.0.0-SNAPSHOT",
+  "type": "module",
   "description": "The Transparency Exchange API specification",
   "scripts": {
     "ipr-check": "node scripts/check-form Ecma-TC54/ECMA-xxx-TEA HEAD --all",
-    "build-head": "npm run build-only -- --lint-spec --strict",
+    "generate-spec": "node index.js",
+    "build-head-strict": "npm run generate-spec && npm run build-only -- --lint-spec --strict",
+    "build-head": "npm run generate-spec && npm run build-only -- --lint-spec",
     "prebuild-only": "npm run clean && mkdir out && cp -R img out",
     "build-only": "ecmarkup --verbose spec.html --multipage out",
     "build": "npm run build-head",
-    "build-for-pdf": "ecmarkup --verbose spec.html --printable --assets external out/index.html",
+    "build-for-pdf": "npm run generate-spec && npm run prebuild-only && ecmarkup --verbose spec.html --printable --assets external out/index.html",
     "pdf": "npm run build-for-pdf",
     "prebuild-snapshot": "npm run clean",
     "build-snapshot": "npm run build-head && node scripts/insert_snapshot_warning.js",
@@ -22,6 +25,13 @@
   "repository": "Ecma-TC54/ECMA-xxx-TEA",
   "author": "ECMA TC54",
   "homepage": "https://tc54.org/tea/",
+  "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^11.7.0",
+    "js-beautify": "^1.15.4",
+    "js-yaml": "^4.1.0",
+    "markdown-it": "^14.1.0",
+    "markdown-it-anchor": "^9.2.0"
+  },
   "devDependencies": {
     "ecmarkup": "21.3.1",
     "glob": "^7.1.6",

--- a/spec.html
+++ b/spec.html
@@ -8,13 +8,16 @@
     padding: 10px;
     border: 1px solid #ee8421;
   }
+
   #metadata-block h1 {
     font-size: 1.5em;
     margin-top: 0;
   }
-  #metadata-block > ul {
+
+  #metadata-block>ul {
     list-style-type: none;
-    margin: 0; padding: 0;
+    margin: 0;
+    padding: 0;
   }
 
   #ecma-logo {
@@ -23,7 +26,7 @@
 
   @page {
     @prince-overlay {
-      color: rgba(0,0,0,0.15);
+      color: rgba(0, 0, 0, 0.15);
       content: "DRAFT";
       font-family: Arial;
       font-weight: bolder;
@@ -32,43 +35,37 @@
     }
   }
 
-  .unicode-property-table {
-    table-layout: fixed;
-    width: 100%;
-    font-size: 80%;
+  figure pre {
+    margin-top: 0;
+    margin-bottom: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
   }
 
-  .corner-cell {
-    position: relative;
-    height: 2lh;
+  code.pattern {
+    font-weight: normal !important;
   }
-  .corner-cell .slash {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: linear-gradient(to bottom left, transparent calc(50% - 1px), gray, transparent calc(50% + 1px));
+
+  .tea-method {
+    display: inline-block;
+    padding: 0.05em 0.4em;
+    border-radius: 0.25em;
+    font-weight: bold;
+    background: #eef;
+    margin-right: 0.4em;
   }
-  .corner-cell > .column {
-    position: absolute;
-    bottom: 0.4em;
-    left: 1em;
+
+  .tea-path {
+    font-family: monospace;
   }
-  .corner-cell > .row {
-    position: absolute;
-    top: 0.4em;
-    right: 1em;
-  }
-</style>
-<pre class="metadata">
+
+</style> <pre class="metadata">
   title: Transparency Exchange API Specification
   shortname: ECMA-xxx
   status: draft
   location: https://tc54.org/ecmaXXX/
   markEffects: true
-</pre>
-<p><img src="img/ecma-logo.svg" id="ecma-logo" alt="Ecma International logo"></p>
+</pre> <p><img src="img/ecma-logo.svg" id="ecma-logo" alt="Ecma International logo"></p>
 <div id="metadata-block">
   <h1>About this Specification</h1>
   <p>The document at <a href="https://tc54.org/ecmaXXX/">https://tc54.org/ecmaXXX/</a> is the most accurate and up-to-date Transparency Exchange API specification.</p>
@@ -76,74 +73,4874 @@
   <h1>Contributing to this Specification</h1>
   <p>This specification is developed on GitHub with the help of the OWASP community. There are a number of ways to contribute to the development of this specification:</p>
   <ul>
-    <li>GitHub Repository: <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA">https://github.com/Ecma-TC54/ECMA-xxx-CLE</a></li>
+    <li>GitHub Repository: <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA">https://github.com/Ecma-TC54/ECMA-xxx-TEA</a></li>
     <li>Issues: <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA/issues">All Issues</a>, <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA/issues/new">File a New Issue</a></li>
     <li>Pull Requests: <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA/pulls">All Pull Requests</a>, <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA/pulls/new">Create a New Pull Request</a></li>
-    <li>
-      Editors:
-      <ul>
+    <li>Source repository (narrative and OpenAPI): <a href="https://github.com/CycloneDX/transparency-exchange-api">https://github.com/CycloneDX/transparency-exchange-api</a></li>
+    <li> Editors: <ul>
         <li><a href="mailto:oej@edvina.net">Olle E Johansson</a></li>
         <li><a href="mailto:steve.springett@owasp.org">Steve Springett</a></li>
       </ul>
     </li>
-    <li>
-      Community:
-      <ul>
+    <li> Community: <ul>
         <li>Chat: <a href="https://cyclonedx.slack.com/archives/C04LR6R9T8E">Slack Channel</a></li>
       </ul>
     </li>
   </ul>
   <p>Refer to the <emu-xref href="#sec-colophon">colophon</emu-xref> for more information on how this document is created.</p>
 </div>
-
 <emu-intro id="sec-intro">
   <h1>Introduction</h1>
-  <p>TODO</p>
+  <p>The TEA API is created to support automation of the software supply chain. Upstream vendors and open source projects can use this standard to keep downstream consumers up to date with transparency artefacts such as, but not limited to, bill of materials, VEX files, attestations and much more.</p>
+  <p>This specification defines a standard, format agnostic, API for the exchange of product related artefacts, like BOMs, between systems. The work includes:</p>
+  <ul>
+    <li><a href="/discovery/readme.md">Discovery of servers</a>: Describes discovery using the Transparency Exchange Identifier (TEI)</li>
+    <li>Retrieval of artefacts</li>
+    <li>Publication of artefacts</li>
+    <li><a href="/auth/readme.md">Authentication and authorization</a></li>
+    <li>Querying</li>
+  </ul>
+  <p>System and tooling implementors are encouraged to adopt this API standard for sending/receiving transparency artefacts between systems. This will enable more widespread &quot;out of the box&quot; integration support in the BOM ecosystem.</p>
 </emu-intro>
-
 <emu-clause id="sec-scope">
   <h1>Scope</h1>
-  <p>This Standard defines the Transparency Exchange API specification.</p>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <p> This Specification defines the Transparency Exchange API (TEA), a format-agnostic protocol for the exchange of software, hardware and system transparency artefacts &mdash; including, but not limited to, Bills of Materials (xBOMs), attestations, vulnerability disclosure documents, and lifecycle events &mdash; between publishers and consumers. </p>
+  <p> The Specification covers: </p>
+  <ul>
+    <li>The Transparency Exchange Identifier (TEI) and its resolution.</li>
+    <li>The data model used to describe products, components, releases, collections and artefacts.</li>
+    <li>The HTTP API surface used to discover, retrieve and (in future revisions) publish transparency artefacts.</li>
+    <li>Authentication and authorization patterns expected of conformant implementations.</li>
+  </ul>
+  <p> The Specification does <em>not</em> define the internal format of the transparency artefacts themselves; those are defined by their respective standards (e.g. CycloneDX, SPDX, OpenVEX, CSAF, CDXA). </p>
 </emu-clause>
-
 <emu-clause id="sec-conformance">
   <h1>Conformance</h1>
-  <p>TODO</p>
-  <p>A conforming implementation of TEA may choose to implement or not implement <dfn>Normative Optional</dfn> subclauses. If any Normative Optional behaviour is implemented, all of the behaviour in the containing Normative Optional clause must be implemented. A Normative Optional clause is denoted in this specification with the words "Normative Optional" in a coloured box, as shown below.</p>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <p> A conformant TEA implementation shall: </p>
+  <ul>
+    <li>Implement the consumer API surface defined in <emu-xref href="#sec-tea-api"></emu-xref> in full.</li>
+    <li>Resolve Transparency Exchange Identifiers per the Discovery chapter.</li>
+    <li>Honour the authentication and authorization model defined in the Authentication chapter.</li>
+    <li>Use the data model defined in <emu-xref href="#sec-tea-data-model"></emu-xref> for request and response payloads.</li>
+  </ul>
+  <p> The terms <strong>shall</strong>, <strong>shall not</strong>, <strong>should</strong>, <strong>should not</strong>, and <strong>may</strong> are to be interpreted as described in IETF RFC 2119 and RFC 8174. </p>
+</emu-clause>
+<emu-clause id="sec-normative-references">
+  <h1>Normative references</h1>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <p> The following referenced documents are indispensable for the application of this Specification. </p>
+  <ul>
+    <li>IETF RFC 2119 &mdash; Key words for use in RFCs to Indicate Requirement Levels.</li>
+    <li>IETF RFC 8174 &mdash; Ambiguity of Uppercase vs Lowercase in RFC 2119 Key Words.</li>
+    <li>IETF RFC 8141 &mdash; Uniform Resource Names (URNs).</li>
+    <li>IETF RFC 7519 &mdash; JSON Web Token (JWT).</li>
+    <li>IETF RFC 9457 &mdash; Problem Details for HTTP APIs.</li>
+    <li>OpenAPI Specification, version 3.1.1.</li>
+    <li>ECMA-424 &mdash; CycloneDX Bill of Materials Specification.</li>
+    <li>ECMA-428 &mdash; Common Lifecycle Enumeration (CLE).</li>
+  </ul>
+</emu-clause>
+<emu-clause id="sec-terms-and-definitions">
+  <h1>Terms and definitions</h1>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <p>For the purposes of this Specification, the following terms and definitions apply.</p>
+  <dl>
+    <dt>API</dt>
+    <dd>Application Programming Interface.</dd>
+    <dt>Authentication (authn)</dt>
+    <dd>The process of verifying the identity of a principal.</dd>
+    <dt>Authorization (authz)</dt>
+    <dd>The process of determining what a verified principal is permitted to do.</dd>
+    <dt>Collection</dt>
+    <dd>A versioned set of TEA Artifacts associated with a specific TEA Release.</dd>
+    <dt>Product</dt>
+    <dd>An item sold, distributed or otherwise delivered under one name.</dd>
+    <dt>Product Release</dt>
+    <dd>A specific version of a Product that can be acquired or downloaded.</dd>
+    <dt>TEA Artifact</dt>
+    <dd>A named file (e.g. an SBOM, an attestation, a VEX document) referenced by a Collection.</dd>
+    <dt>TEI</dt>
+    <dd>Transparency Exchange Identifier &mdash; a URN that resolves to a TEA Product Release.</dd>
+  </dl>
+</emu-clause>
+<emu-clause id="sec-tea-narrative">
+  <h1>Specification narrative</h1>
+  <p>The following sections are derived from the working group's authoring notes maintained as Markdown in the source repository.</p>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:doc/tea-requirements.md -->
+  <emu-clause id="sec-req-1-tea-requirements">
+    <h1>TEA Requirements</h1>
+    <emu-clause id="sec-req-2-repository-discovery">
+      <h1>Repository discovery</h1>
+      <p>Based on an identifier a repository URL needs to be found. The identifier can be:</p>
+      <ul>
+        <li>PURL</li>
+        <li>Product name or Product SKU and vendor name</li>
+        <li>EAN bar code</li>
+        <li>Product SKU</li>
+        <li>Vendor UUID</li>
+        <li>Hash of object</li>
+      </ul>
+      <p>At the base URL well known URLs (ref) needs to point to</p>
+      <ul>
+        <li>A lifecycle status document (using OWASP Common Lifecycle Enumeration, CLE)</li>
+        <li>A version list. For each version, a URL will point to where a <strong>collection</strong> can be found</li>
+        <li>Vendor Discovery, returns a list of Vendors represented in the repository <ul>
+            <li>Vendor Name</li>
+            <li>Vendor ID</li>
+          </ul>
+        </li>
+      </ul>
+      <p>As an alternative, discovery using a company's ordinary web site should be supported. This can be handled using the file security.txt (IETF RFC 9116)</p>
+    </emu-clause>
+    <emu-clause id="sec-req-3-artefact-discovery-based-on-tea-collections">
+      <h1>Artefact Discovery based on TEA collections</h1>
+      <p>The API MUST provide a way to discover the artefacts that are available for retrieval or further query. Discovery SHOULD group artefacts together that represent a <strong>collection</strong> that are directly applicable to a given product with a given version. Collections are OPTIONAL.</p>
+      <ul>
+        <li>SBOM - Software Bill of Material</li>
+        <li>CBOM - Cryptography Bill of Material</li>
+        <li>HBOM - Hardware Bill of Material</li>
+        <li>VDR - Vulnerability Disclosure Report</li>
+        <li>VEX - Vulnerability Exploitability eXchange</li>
+        <li>CDXA - Attestation</li>
+      </ul>
+      <p>Authn/Authz MUST be supported</p>
+    </emu-clause>
+    <emu-clause id="sec-req-4-collection-management">
+      <h1>Collection Management</h1>
+      <p>The API SHOULD provide a method to manage collections, such as adding new collections, modifying collections, or deleting existing collections.</p>
+      <ul>
+        <li>Authn/Authz MUST be supported</li>
+      </ul>
+    </emu-clause>
+    <emu-clause id="sec-req-5-artefact-retrieval">
+      <h1>Artefact Retrieval</h1>
+      <p>The API MUST provide a method in which to retrieve an artefact based on the identity of the artefact. For example, using CycloneDX BOM-Link to retrieve either the latest version or specific version of an artefact.</p> <pre><code>urn:cdx:serialNumber
+urn:cdx:serialNumber/version
+</code></pre> <p>The API needs to provide support for update checks, i.e. to check if a document is updated without downloading. (possibly etag or HEAD method or similar) Authn/Authz MUST be supported</p>
+    </emu-clause>
+    <emu-clause id="sec-req-6-artefact-publishing">
+      <h1>Artefact Publishing</h1>
+      <p>The API MUST provide a way to publish an artefact, either standalone or to a collection. The detection of duplicate artefacts with the same identity MUST be handled and prevented. Authn/Authz MUST be supported</p>
+    </emu-clause>
+    <emu-clause id="sec-req-7-artefact-versioning">
+      <h1>Artefact Versioning</h1>
+      <p>The system and API must support artefact versioning for formats that support versioning such as CycloneDX. For example:</p>
+      <ul>
+        <li>The ability to retrieve the latest SBOM vs a previous (uncorrected) version of the same SBOM. Corrections to SBOMs is a supported use case in the NTIA framing document.</li>
+        <li>The ability to retrieve the latest VEX along with previous VEX for the same product so that time-series decisions are transparently available.</li>
+      </ul>
+      <p>Authn/Authz MUST be supported</p>
+    </emu-clause>
+    <emu-clause id="sec-req-8-insights-search-artefact-inventory">
+      <h1>insights: Search Artefact Inventory</h1>
+      <p>The API MUST provide a way to search the inventory of a specific BOM or all available BOMs for a given component or service. The API SHOULD support multiple identity formats including PURL, CPE, SWID, GAV, GTIN, and GMN.</p>
+      <p>For example:</p>
+      <ul>
+        <li>Return the identity of all BOMs that have a vulnerable version of Apache Log4J: <code>pkg:maven/org.apache.logging.log4j/log4j-core@2.10.0</code></li>
+      </ul>
+      <p>The API MUST provide a way to search for the metadata component across all available BOMs. The API SHOULD support multiple identity formats including PURL, CPE, SWID, GAV, GTIN, and GMN. For example:</p>
+      <ul>
+        <li>Return the identity of all artefacts that describe <code>cpe:/a:acme:commerce_suite:1.0</code>.</li>
+      </ul>
+      <p>Authn/Authz MUST be supported</p>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:doc/tea-usecases.md -->
+  <emu-clause id="sec-uc-1-tea-use-cases">
+    <h1>TEA Use Cases</h1>
+    <p>An overview of use cases to consider for the Transparency Exchange API. The use cases are marked with a short code for reference. All use cases needs a story like &quot;Alice has bought a...&quot;</p>
+    <p>The use cases are divided in two categories:</p>
+    <ul>
+      <li>Use cases for <strong>customers</strong> (end-users, manufacturers) to find a repository with Transparency artefacts for a single unit purchased</li>
+      <li>Use cases where there are different <strong>products</strong>
+        <ul>
+          <li>This applies after discovery where we need to handle various things a customer may buy as a single unit</li>
+        </ul>
+      </li>
+    </ul>
+    <emu-clause id="sec-uc-2-customer-focused-use-cases">
+      <h1>Customer focused use cases</h1>
+      <emu-clause id="sec-uc-3-c1-consumer-automated-discovery-based-on-sbom-identifier">
+        <h1>C1: Consumer: Automated discovery based on SBOM identifier</h1>
+        <p>As a consumer that has an SBOM for a product, I want to be able to retrieve VEX and VDR files automatically both for current and old versions of the software. In the SBOM the product is identified by a PURL or other means (CPE, …)</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-4-c2-consumer-automation-based-on-product-name-identifier">
+        <h1>C2: Consumer: Automation based on product name/identifier</h1>
+        <p>As a consumer, I want to download artefacts for a product based on known data. A combination of manufacturer, product name, vendor product ID, EAN bar code or other unique identifier. After discovering the base repository URL I want to be able to find a specific product variant and version.</p>
+        <p>If the consumer is a business, then the procurement process may include delivery of an SBOM with proper identifiers and possibly URLs or identifiers in another document, which may bootstrap the discovery process in a more exact way than in the case of buying a product in a retail market. Alice bought a gadget at the gadget store that contains a full Linux system. Where and how will she find the SBOM and VEX for the gadget?</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-5-c3-consumer-artefact-retrieval">
+        <h1>C3: Consumer: Artefact retrieval</h1>
+        <p>As a consumer, I want to retrieve one or more supply chain artefacts for the products that I have access to, possibly through licensing or other means. As a consumer, I should be able to retrieve all source artefacts such as xBOMs, VDR/VEX, CDXA, and CLE.</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-6-c4-consumer-summarized-cle">
+        <h1>C4: Consumer: Summarized CLE</h1>
+        <p>As a consumer, I want the ability to get the current lifecycle values for a given product. A CLE captures all lifecycle events over time, however, there is a need to retrieve only the current values for things like product name, vendor name, and milestone events.</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-7-c5-consumer-insights">
+        <h1>C5: Consumer: Insights</h1>
+        <p>As a consumer, I want the ability to simply ask the API questions rather than having to download, process, and analyze raw supply chain artefacts on my own systems. Common questions should be provided by the API by default along with the ability to query for more complex answers using the Common Expression Language (CEL).</p>
+        <p><em>NOTE</em>: Project Hyades (Dependency-Track v5) already implements CEL with the CycloneDX object model and has proven that this approach works for complex queries.</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-8-d1-developer-pm-components-for-inclusion-in-products-by-other-projects-developer">
+        <h1>D1: Developer/PM - Components for inclusion in products by other projects/developers</h1>
+        <p>A developer needs a component - software, library (open source and/or proprietary) to include in a product - publicly available (may be commercial) or in an internal system. Developer can be individual, company or public sector. They need insight into the library or component and be able to automatically keep upstream artefacts up to date.</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-9-b1-business-consumer">
+        <h1>B1: Business consumer</h1>
+        <p>Acme LLC buys 3 000 gadgetrons from Emca LTD to be distributed over a retail chain. Acme runs an in-house vulnerability management system (Dependency Track) to manage SBOMs and download VEX files to check for vulnerabilities. Acme has products from exactly 14.385 vendors in the system. How will their systems get continuous access to current and old documents - attestations, SBOM, VEX and other files?</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-10-e1-third-party-regulators">
+        <h1>E1: Third party: Regulators</h1>
+        <p>Alice &amp; Bob Enterprises AB has gotten a EUCC certification to get their Whola Firewall certified for CRA-compatible CE labeling. In order to maintain the certification the certifying body needs access to SBOM and VEX updates from A&amp;BE in an automated way.</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-11-e2-external-potential-customer-insights-before-purchase">
+        <h1>E2: External potential customer - insights before purchase</h1>
+        <p>Palme Auditors INC wants to buy the ACME SWISH product from a vendor. They want to examine vulnerability handling and get some insights into the products before making a decision.</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-12-e3-hacker-or-competition">
+        <h1>E3: Hacker or competition</h1>
+        <p>There are non-customers and not-to-be-customers that wants to get insight into how a product is composed by getting the transparency docs.</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-13-e4-open-source-user">
+        <h1>E4: Open Source user</h1>
+        <p>Palme Inc considers using the <a href="http://asterisk.org">asterisk.org</a> open source telephony PBX. They need to make an assessment before starting tests and possible production use. The can either use the Debian package, the Alpine Linux Package or build a binary themselves from source code. How can they find the transparency exchange data sets?</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-14-o1-open-source-project">
+        <h1>O1: Open Source project</h1>
+        <p>The hatturl open source project publish a library and a server side software on Github. This is later packaged as packages in many Linux distributions.</p>
+        <p>How does the project publish artefacts? What are the requirements?</p>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-uc-15-product-focused-use-cases">
+      <h1>Product focused use cases</h1>
+      <emu-clause id="sec-uc-16-p1-a-standalone-app">
+        <h1>P1: A standalone app</h1>
+        <p>Customer buys a standalone application that is delivered as a binary</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-17-p2-a-oci-container">
+        <h1>P2: A OCI container</h1>
+        <p>Customer gets a container with many third party components and a binary software developed by the manufacturer</p>
+      </emu-clause>
+      <emu-clause id="sec-uc-18-p3-embedded-system">
+        <h1>P3: Embedded system</h1>
+      </emu-clause>
+      <emu-clause id="sec-uc-19-p4-package-with-many-devices">
+        <h1>P4: Package with many devices</h1>
+      </emu-clause>
+      <emu-clause id="sec-uc-20-p5-an-open-source-software-library">
+        <h1>P5: An Open Source software library</h1>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:discovery/readme.md -->
+  <emu-clause id="sec-discovery-1-transparency-exchange-api-discovery">
+    <h1>Transparency Exchange API - Discovery</h1>
+    <emu-clause id="sec-discovery-2-from-product-identifier-to-api-endpoint">
+      <h1>From product identifier to API endpoint</h1>
+      <p>TEA Discovery is the connection between a product release identifier and the API endpoint. A &quot;product release&quot; is something that the customer aquires or downloads - hardware and/or software.</p>
+      <p>It can be a bundle of many digital devices or software applications. A &quot;product release&quot; normally also has an entry in a large corporation's asset inventory system.</p>
+      <p>A product release identifier is embedded in a URN where the identifier is one of many existing identifiers or a random string - like an EAN or UPC bar code, UUID, product number or PURL.</p>
+      <p>The goal is for a user to add this URN to the transparency platform (sometimes with an associated authentication token) and have the platform access the required artefacts in a highly automated fashion.</p>
+    </emu-clause>
+    <emu-clause id="sec-discovery-3-advertising-the-tei">
+      <h1>Advertising the TEI</h1>
+      <p>The TEI for a product release can be communicated to the user in many ways.</p>
+      <ul>
+        <li>A QR code on a box</li>
+        <li>On the invoice or delivery note</li>
+        <li>For software with a GUI, in an &quot;about&quot; box</li>
+      </ul>
+      <p>The user needs to get the TEI from the manufacturer, through a reseller or directly. The TEI is defined by the manufacturer and can normally not be derived from known information.</p>
+    </emu-clause>
+    <emu-clause id="sec-discovery-4-tea-discovery-defining-an-extensible-identifier">
+      <h1>TEA Discovery - defining an extensible identifier</h1>
+      <p>TEA discovery is the process where a user with a product release identifier can discover and download artefacts automatically, with or without authentication. A globally unique identifier is required for a given product release. This identifier is called the Transparency Exchange Identifier (TEI).</p>
+      <p>The TEI identifier is based on DNS, which assures a uniqueness per vendor (or open source project) and gives the vendor a namespace to define product release identifiers based on existing or new identifiers like EAN/UPC bar code, PURLs or other existing schemes. A given product release may have multiple identifiers as long as they all resolve into the same destination.</p>
+      <p>The vendor needs to make sure that the TEI is unique within the vendor's namespace. There is no intention to create any TEI registries.</p>
+    </emu-clause>
+    <emu-clause id="sec-discovery-5-the-tei-urn-an-extensible-identifier">
+      <h1>The TEI URN: An extensible identifier</h1>
+      <p>The TEI, <strong>Transparency Exchange Identifier</strong>, is a URN schema that is extensible based on existing identifiers like EAN codes, PURL and other identifiers. It is based on a DNS name, which leads to global uniqueness without new registries.</p>
+      <p>The TEI can be shown in the software itself, in shipping documentation, in web pages and app stores.</p>
+      <p>A TEI belongs to a single product release. A product release can have multiple TEIs - like one with a EAN/UPC barcode and one with the vendor's product number.</p>
+      <emu-clause id="sec-discovery-6-tei-syntax">
+        <h1>TEI syntax</h1>
+        <p>The TEI consists of three core parts</p> <pre><code>urn:tei:&lt;type&gt;:&lt;domain-name&gt;:&lt;unique-identifier&gt;
+</code></pre> <ul>
+          <li>The <strong><code>type</code></strong> which defines the syntax of the unique identifier part</li>
+          <li>The <strong><code>domain-name</code></strong> part resolves into a web server, which may not be the API host. <ul>
+              <li>The uniqueness of the name is the domain name part that has to be registred at creation of the TEI.</li>
+            </ul>
+          </li>
+          <li>The <strong><code>unique-identifier</code></strong> has to be unique within the <code>domain-name</code>. Recommendation is to use a UUID but it can be an existing article code too</li>
+        </ul>
+        <p><strong>Note</strong>: this requires a registration of the TEI URN schema with IANA - <a href="https://github.com/CycloneDX/transparency-exchange-api/issues/18">see here</a></p>
+      </emu-clause>
+      <emu-clause id="sec-discovery-7-tei-types">
+        <h1>TEI types</h1>
+        <p>The below show examples of TEI where the types are specific known formats or types.</p>
+        <p>Reminder: the <code>unique-identifer</code> component of the TEI needs only be unique within the <code>domain-name</code>.</p>
+        <emu-clause id="sec-discovery-8-purl-package-url">
+          <h1>PURL - Package URL</h1>
+          <p>Where the <code>unique-identifier</code> is a PURL in it's canonical string form.</p>
+          <p>Syntax:</p> <pre><code>urn:tei:purl:&lt;domain-name&gt;:&lt;purl&gt;
+</code></pre> <p>Example:</p> <pre><code>urn:tei:purl:cyclonedx.org:pkg:pypi/cyclonedx-python-lib@8.4.0?extension=whl&amp;qualifier=py3-none-any
+</code></pre>
+        </emu-clause>
+        <emu-clause id="sec-discovery-9-swid">
+          <h1>SWID</h1>
+          <p>Where the <code>unique-identifier</code> is a SWID.</p>
+          <p>Syntax:</p> <pre><code>urn:tei:swid:&lt;domain-name&gt;:&lt;swid&gt;
+</code></pre> <p>Note that there is a TEI SWID type as well as a PURL SWID type.</p>
+        </emu-clause>
+        <emu-clause id="sec-discovery-10-hash">
+          <h1>HASH</h1>
+          <p>Where the <code>unique-identifier</code> is a Hash. Supports the following hash types:</p>
+          <ul>
+            <li>SHA256</li>
+            <li>SHA384</li>
+            <li>SHA512</li>
+          </ul> <pre><code>urn:tei:hash:&lt;domain-name&gt;:&lt;hashtype&gt;:&lt;hash&gt;
+</code></pre> <p>Example:</p> <pre><code>urn:tei:hash:cyclonedx.org:SHA256:fd44efd601f651c8865acf0dfeacb0df19a2b50ec69ead0262096fd2f67197b9
+</code></pre> <p>The origin of the hash is up to the vendor to define.</p>
+        </emu-clause>
+        <emu-clause id="sec-discovery-11-uuid">
+          <h1>UUID</h1>
+          <p>Where the <code>unique-identifier</code> is a UUID.</p>
+          <p>Syntax:</p> <pre><code>urn:tei:uuid:&lt;domain-name&gt;:&lt;uuid&gt;
+</code></pre> <p>Example:</p> <pre><code>urn:tei:uuid:cyclonedx.org:d4d9f54a-abcf-11ee-ac79-1a52914d44b1
+</code></pre>
+        </emu-clause>
+        <emu-clause id="sec-discovery-12-ean-upc">
+          <h1>EAN/UPC</h1>
+          <p>Where the <code>unique-identifier</code> is a EAN/UPC.</p>
+          <p>Syntax:</p> <pre><code>urn:tei:eanupc:&lt;domain-name&gt;:&lt;ean/upc-number&gt;
+</code></pre> <p>Example:</p> <pre><code>urn:tei:eanupc:cyclonedx.org:1234567890123
+</code></pre>
+        </emu-clause>
+        <emu-clause id="sec-discovery-13-gtin">
+          <h1>GTIN</h1>
+          <p>Where the <code>unique-identifier</code> is a <a href="https://www.gs1.org/standards/id-keys/gtin">GTIN</a>.</p>
+          <p>Syntax:</p> <pre><code>urn:tei:gtin:&lt;domain-name&gt;:&lt;gtin-number&gt;
+</code></pre> <p>Example:</p> <pre><code>urn:tei:gtin:cyclonedx.org:0234567890123
+</code></pre>
+        </emu-clause>
+        <emu-clause id="sec-discovery-14-asin">
+          <h1>ASIN</h1>
+          <p>Where the <code>unique-identifier</code> is a <a href="https://sell.amazon.com/blog/what-is-an-asin">ASIN</a>.</p>
+          <p>Syntax:</p> <pre><code>urn:tei:asin:&lt;domain-name&gt;:&lt;asin-identifier&gt;
+</code></pre> <p>Example:</p> <pre><code>urn:tei:asin:cyclonedx.org:B07FZ8S74R
+</code></pre>
+        </emu-clause>
+        <emu-clause id="sec-discovery-15-udi">
+          <h1>UDI</h1>
+          <p>Where the <code>unique-identifier</code> is a <a href="https://www.gs1.org/industries/healthcare/udi">UDI</a>.</p>
+          <p>Syntax:</p> <pre><code>urn:tei:udi:&lt;domain-name&gt;:&lt;udi-identifier&gt;
+</code></pre> <p>Example:</p> <pre><code>urn:tei:udi:cyclonedx.org:00123456789012
+</code></pre> <p>Note that if the same identifier, like EAN, is used for multiple different product releases then this EAN code will not be unique for a given product. While this case is supported by TEA, the vendor is recommended to create a separate TEI for each unique product sold, like UUID or hash. In any case, the vendor SHOULD minimize the number of distinct product releases returned per TEI. Preferable situation is to have a single product release per TEI.</p>
+        </emu-clause>
+      </emu-clause>
+      <emu-clause id="sec-discovery-16-tei-resolution-using-dns">
+        <h1>TEI resolution using DNS</h1>
+        <p>The <code>domain-name</code> part of the TEI is used in a DNS query to find one or multiple locations for product transparency exchange information.</p>
+        <p>At the URL a well-known name space is used to find out where the API endpoint is hosted. This is solved by using the &quot;.well-known&quot; name space as defined by the IETF.</p>
+        <ul>
+          <li><code>urn:tei:uuid:products.example.com:d4d9f54a-abcf-11ee-ac79-1a52914d44b1</code></li>
+          <li>Syntax: <code>urn:tei:uuid:&lt;name based on domain&gt;:&lt;unique identifier&gt;</code></li>
+        </ul>
+        <p>The name in the DNS name part points to a set of DNS records.</p>
+        <p>A TEI with <code>domain-name</code> <code>tea.example.com</code> queries DNS for <code>tea.example.com</code>, considering <code>A</code>, <code>AAAA</code> and <code>CNAME</code> records. These point to the hosts available for the Transparency Exchange API.</p>
+        <p>The TEA client connects to the host using HTTPS and validates the certificate. The URL is composed of the host name with the <code>/.well-known/tea</code> path added.</p>
+        <p>This results in the base URL such as <code>https://products.example.com/.well-known/tea</code></p>
+        <p>This response must contain json object that lists the available TEA server endpoints and supported versions. The json must conform to the <a href="tea-well-known.schema.json">TEA Well-Known Schema</a>.</p>
+        <p>Example:</p> <pre><code class="language-json">{
+  &quot;schemaVersion&quot;: 1,
+  &quot;endpoints&quot;: [
+    {
+      &quot;url&quot;: &quot;https://api.teaexample.com&quot;,
+      &quot;versions&quot;: 
+        [
+          &quot;0.1.0-beta.1&quot;,
+          &quot;0.2.0-beta.2&quot;,
+          &quot;1.0.0&quot;
+        ],
+      &quot;priority&quot;: 1
+    },
+    {
+      &quot;url&quot;: &quot;https://api2.teaexample.com/mytea&quot;,
+      &quot;versions&quot;: 
+        [
+          &quot;1.0.0&quot;
+        ],
+      &quot;priority&quot;: 0.5
+    }
+  ]
+}
+</code></pre>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-discovery-17-port-resolution">
+      <h1>Port resolution</h1>
+      <p>Currently, the port number is not part of the TEI but it is needed to connect to the API. A port number cannot be added to the TEI URN spec as it breaks the location independence requirement of URN.</p>
+      <p>The TEA API server may be hosted on any port, but the server that is part of the first step of discovery will by default be running on the default HTTPS port 443. In the JSON file found there, the server URLs may contain port numbers.</p>
+      <p>If the clients are known to support HTTPS/SVCB DNS records for failover and load balancing, these may be used to redirect to other ports and servers.</p>
+      <p>Public servers are recommended to have the server hosting the DNS name used in the TEI URI running on the default port to enable discovery of the API servers.</p>
+    </emu-clause>
+    <emu-clause id="sec-discovery-18-connecting-to-the-api">
+      <h1>Connecting to the API</h1>
+      <p>Clients must pick any one of the endpoints listed in the <code>.well-known/tea</code> json response. The client MUST pick an endpoint with the at least one version that is supported by the client is using. The client MUST prioritize endpoints with the highest matching version supported both by the client and the endpoint based on SemVer 2.0.0 specification comparison <a href="https://semver.org/#spec-item-11">rules</a>. If there are several endpoints like these and if the priority field is present, the client SHOULD pick the endpoint with the highest priority value (a float between 0 and 1).</p>
+      <p>The client must then construct the full URL to the API by appending the &quot;/v&quot; plus one of the versions listed in the <code>versions</code> array of the selected endpoint, plus &quot;/discovery?tei=&quot;, plus the TEI that is url-encoded according to [RFC3986] and [RFC3986]).</p>
+      <p>Examples:</p>
+      <ol>
+        <li>For TEI <code>urn:tei:uuid:products.example.com:d4d9f54a-abcf-11ee-ac79-1a52914d44b</code> <code>https://api.teaexample.com/v0.2.0-beta.2/discovery?tei=urn%3Atei%3Auuid%3Aproducts.example.com%3Ad4d9f54a-abcf-11ee-ac79-1a52914d44b</code></li>
+        <li>For TEI <code>urn:tei:purl:products.example.com:pkg:deb/debian/curl@7.50.3-1?arch=i386&amp;distro=jessie</code> <code>https://api2.teaexample.com/mytea/v1.0.0/discovery?tei=urn%3Atei%3Apurl%3Aproducts.example.com%3Apkg%3Adeb%2Fdebian%2Fcurl%407.50.3-1%3Farch%3Di386%26distro%3Djessie</code></li>
+      </ol>
+      <p>The discovery endpoint is a part of the TEA OpenAPI specification.</p>
+      <p>If the TEI is known to the TEA server, the discovery endpoint must return at least the product release uuid, the root URL of the TEA server, the list of supported versions, plus the response may have other fields based on the current version of the TEA OpenAPI specification.</p>
+      <p>If the TEI is not known to the TEA server, the discovery endpoint must return a 404 status code with a response describing the error.</p>
+      <p>If the DNS record for the discovery endpoint cannot be resolved by the client, or the discovery endpoint fails with 5xx error code, or the TLS certificate cannot be validated, the client MUST retry the discovery endpoint with the next endpoint in the list, if another endpoint is present. While doing so the client SHOULD preserve the priority order if provided (from highest to lowest priority). If no other endpoint is available, the client MUST retry the discovery endpoint with the first endpoint in the list. The client SHOULD implement an exponential backoff strategy for retries.</p>
+      <p>Client implementations needs to indicate authentication errors clearly to the users, to indicate that there are no updates. An expired token or TLS Client Cert will mean that new versions of a product or updated artefacts will not be accessed. Authentication error codes (401, 403) should not lead to failover to the next endpoint in the list.</p>
+      <p>How this is communicated to the client users is implementation specific.</p>
+    </emu-clause>
+    <emu-clause id="sec-discovery-19-notes-regarding-well-known">
+      <h1>Notes Regarding .well-known</h1>
+      <p>Servers MUST NOT locate the actual TEA service endpoint at the <code>.well-known</code> URI as per Section 1.1 of [RFC5785].</p>
+      <emu-clause id="sec-discovery-20-tls-encryption">
+        <h1>TLS Encryption</h1>
+        <p>The .well-known endpoint must only be available via HTTPS. Using unencrypted HTTP is not valid.</p>
+        <ul>
+          <li>TEI: <code>urn:tei:uuid:products.example.com:d4d9f54a-abcf-11ee-ac79-1a52914d44b1</code></li>
+          <li>URL: <code>https://products.example.com/.well-known/tea</code></li>
+        </ul>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-discovery-21-references">
+      <h1>References</h1>
+      <ul>
+        <li><a href="https://www.iana.org/assignments/well-known-uris/well-known-uris.xhtml">IANA .well-known registry</a></li>
+        <li><a href="https://www.iana.org/assignments/urn-namespaces/urn-namespaces.xhtml#urn-namespaces-1">IANA URI registry</a></li>
+      </ul>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:auth/readme.md -->
+  <emu-clause id="sec-auth-1-transparency-exchange-api-authentication-and-authorization">
+    <h1>Transparency Exchange API - Authentication and authorization</h1>
+    <p>This document covers authentication and authorization on the consumer side of a TEA service - the discovery and download of software transparency artefacts.</p>
+    <emu-clause id="sec-auth-2-requirements">
+      <h1>Requirements</h1>
+      <p><strong>Authorization</strong>: A user of a TEA service may get access to all objects (components, collections) and artefacts or just a subset, depending on the publisher of the data. Authorization is connected to <strong>authentication</strong>.</p>
+      <p>The level of authorization is up to the implementer of the TEA implementation and the publisher, whether an identity gets access to all objects in a service or just a subset.</p>
+      <p>In order to get interoperability between clients and servers implementing the protocol, the specification focuses on the authentication. After successful authentication, the authorization may be implemented in multiple ways - on various levels of the API - depending on what information the user can access.</p>
+      <p>As an example, one implementation may publish all information about existing artefacts and software versions openly, but restrict access to artefacts to those that match the customers installation. Another implementation can implement a filter that does not show products and versions (&quot;components&quot;) that the customer has not aquired.</p>
+      <p>For most Open Source projects, implementing authentication - setting up accounts and managing authorization - does not make much sense, since the information is usually in the open any way.</p>
+      <p>This specification does not impose any requirement on authentication on a TEA service. But should the provider implement authentication, two methods are supported in order to promote interoperability.</p>
+      <ul>
+        <li>HTTP Bearer Token Authentication</li>
+        <li>Mutual TLS with verifiable client and server certificates</li>
+      </ul>
+      <p>A client may use both HTTP bearer token auth and TLS client certificates when accessing multiple TEA services. It is up to the service provider to select authentication.</p>
+    </emu-clause>
+    <emu-clause id="sec-auth-3-http-bearer-token-auth">
+      <h1>HTTP bearer token auth</h1>
+      <p>The API will support HTTP bearer token in the <strong>Authorization:</strong> http header. How the token is aquired is out of scope for this specification, as is the potential content of the token.</p>
+      <p>As an example the token can be downloaded from a customer support portal with a long-term validity. This token is then installed into the software transparency platform (the TEA client) and used to automatically retrieve software transparency artefacts.</p>
+      <p>For each TEA service, one bearer token is needed. The token itself (or the backend) should specify authorization for the token.</p>
+    </emu-clause>
+    <emu-clause id="sec-auth-4-mutual-tls">
+      <h1>Mutual TLS</h1>
+      <p>For Mutual TLS the client certificates will be managed by the service and provided in a service-specific way. Clients should be able to configure a separate client certificate (and private key) on a per-service level, not assuming that a client certificate for one service is trusted anywhere else.</p>
+    </emu-clause>
+    <emu-clause id="sec-auth-5-references">
+      <h1>References</h1>
+      <ul>
+        <li>RFC 6750: The Oauth 2.0 Authorization Framework: Bearer Token Usage (<a href="https://www.rfc-editor.org/rfc/rfc6750">https://www.rfc-editor.org/rfc/rfc6750</a>)</li>
+      </ul>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:api-flow/consumer.md -->
+  <emu-clause id="sec-flow-consumer-1-transparency-exchange-api-consumer-access">
+    <h1>Transparency Exchange API: Consumer access</h1>
+    <p>The consumer access starts with a TEI, A transparency Exchange Identifier. This is used to find the API server as described in the <a href="/discovery/readme.md">discovery document</a>.</p>
+    <emu-clause id="sec-flow-consumer-2-api-usage">
+      <h1>API usage</h1>
+      <p>The standard TEI points to a product release. A product release is something sold, downloaded as an opensource project or aquired by other means. It contains one or multiple component releases.</p>
+      <ul>
+        <li><strong>List of TEA Component Rleases</strong>: Component releases are components of a product release. Each Component release has its own versioning and its own set of artefacts, they have a timestamp and a lifecycle enumeration. They are normally sorted by timestamps. The TEA API has no requirements of type of version string (semantic or any other scheme) - it's just an identifier set by the manufacturer.</li>
+        <li><strong>List of TEA Collections</strong>: For each release, there is a list of TEA collections as indicated by release date and a version integer starting with collection version 1.</li>
+        <li><strong>List of TEA Artifacts</strong>: The collection is unique for a version and contains a list of artefacts. This can be SBOM files, VEX, SCITT, IN-TOTO or other documents. Note that a single artefact can belong to multiple Component or Product Releases.</li>
+        <li><strong>List of artefact formats</strong>: An artefact can be published in multiple formats.</li>
+      </ul>
+      <p>The user has to know product release TEI and in some cases version of each component (TEA Component Release) to find the list of artefacts for the particular Product Release.</p>
+    </emu-clause>
+    <emu-clause id="sec-flow-consumer-3-api-flow-based-on-tei-discovery">
+      <h1>API flow based on TEI discovery</h1> <pre><code>
+---
+title: TEA consumer flow
+---
+sequenceDiagram
+    autonumber
+    actor manufacturer as Manufacturer
+    actor user as TEA Client
 
-  <emu-clause id="sec-conformance-normative-optional" oldids="sec-conformance.normative-optional" example normative-optional>
-    <h1>Example Normative Optional Clause Heading</h1>
-    <p>Example clause contents.</p>
+    participant discovery as TEA Discovery / TEA Server
+    participant tea_product_release as TEA Product Release
+    participant tea_component_release as TEA Component Release
+
+    manufacturer -&gt;&gt; user: Provides TEI (Transparency Exchange Identifier)
+
+    user -&gt;&gt; discovery: GET https://&lt;domain&gt;/.well-known/tea
+    discovery --&gt;&gt; user: TEA discovery document (API servers &amp; endpoints)
+
+    user -&gt;&gt; discovery: Call Discovery endpoint with TEI
+    discovery --&gt;&gt; user: Product Release reference(s)
+
+    alt Multiple Product Releases returned
+        user -&gt;&gt; tea_product_release: Resolve Product Release(s)
+        tea_product_release --&gt;&gt; user: List of Component Releases
+        user -&gt;&gt; user: Identify Discriminating Component Releases
+        user -&gt;&gt; tea_component_release: Resolve Discriminating Component Releases
+        tea_component_release --&gt;&gt; user: Discriminating Component Release Details
+        user -&gt;&gt; user: Converge on a Single Product Release
+    end
+
+    user -&gt;&gt; tea_product_release: Resolve Product Release Details
+    tea_product_release --&gt;&gt; user: List of Component Releases
+
+    loop For each tea_component_release
+        user -&gt;&gt; tea_component_release: Obtain latest collections
+        tea_component_release --&gt;&gt; user: List of TEA Artifacts
+    end
+
+</code></pre>
+    </emu-clause>
+    <emu-clause id="sec-flow-consumer-4-api-flow-based-on-direct-access-to-api">
+      <h1>API flow based on direct access to API</h1>
+      <p>In this case, the client wants to search for a specific product release using the API</p> <pre><code>
+---
+title: TEA client flow with search
+---
+
+sequenceDiagram
+    autonumber
+    actor user
+
+    participant tea_product_release as TEA Product Release
+    participant tea_component_release as TEA Component Release
+    participant tea_collection as TEA Collection
+    participant tea_artifact as TEA Artifact
+
+
+    user -&gt;&gt; tea_product_release: Search for product releases based on identifier (CPE, PURL, name)
+    tea_product_release -&gt;&gt; user: List of product releases
+
+    user -&gt;&gt; tea_product_release: Finding all product parts (TEA Component Releases) and facts about choosen product
+    tea_product_release -&gt;&gt; user: List of TEA Component Releases
+
+    user -&gt;&gt; tea_component_release: Finding information of a component release
+    tea_component_release -&gt;&gt; user: List of releases and collection id for each release
+
+    user -&gt;&gt; tea_collection: Finding all TEA Artifacts for TEA Component Release
+    tea_collection -&gt;&gt; user: List of TEA Artifacts and formats available for each TEA Artifact
+
+    user -&gt;&gt; tea_artifact: Request to download TEA artifact
+    tea_artifact -&gt;&gt; user: TEA Artifact
+
+</code></pre>
+    </emu-clause>
+    <emu-clause id="sec-flow-consumer-5-api-flow-based-on-cached-data-checking-for-a-new-release">
+      <h1>API flow based on cached data - checking for a new release</h1>
+      <p>In this case a TEA client knows the component UUID and wants to check the status of the used release and if there's a new release. The client may limit the query with a given date for a release.</p> <pre><code>
+---
+title: TEA client flow with direct query for release
+---
+
+sequenceDiagram
+    autonumber
+    actor user
+
+    participant tea_component as TEA Component
+    participant tea_component_release as TEA Component Release
+
+    user -&gt;&gt; tea_component: Finding a specific version/release
+    tea_component -&gt;&gt; user: List of releases and collection id for each release
+
+    user -&gt;&gt; tea_component_release: Details for discovered release
+    tea_component_release -&gt;&gt; user: Collection with artefact details for the release
+
+</code></pre>
+    </emu-clause>
+    <emu-clause id="sec-flow-consumer-6-api-flow-based-on-cached-data-checking-if-a-collection-changed">
+      <h1>API flow based on cached data - checking if a collection changed</h1>
+      <p>In this case a TEA client knows the release UUID, the collection UUID, and the collection version from previous queries. If the given version is not the same, another query is done to get reason for update and new collection list of artefacts.</p> <pre><code>
+---
+title: TEA client collection query
+---
+
+sequenceDiagram
+    autonumber
+    actor user
+
+    participant tea_collection as TEA Collection
+
+
+    user -&gt;&gt; tea_collection: Finding the current collection, including version
+    tea_collection -&gt;&gt; user: List of artefacts and formats available for each artefact
+
+    user -&gt;&gt; tea_collection: Request to access previous version of the collection to compare
+    tea_collection -&gt;&gt; user: Previous version of collection
+
+</code></pre>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:api-flow/publisher.md -->
+  <emu-clause id="sec-flow-publisher-1-overview-of-the-tea-api-from-a-producer-standpoint">
+    <h1>Overview of the TEA API from a producer standpoint</h1>
+    <p>This is input for the working group.</p>
+    <emu-clause id="sec-flow-publisher-2-bootstrapping">
+      <h1>Bootstrapping</h1> <pre><code>
+sequenceDiagram
+    autonumber
+    actor Vendor
+    participant tea_product as TEA Product
+    participant tea_component as TEA Component
+    participant tea_collection as TEA Collection
+
+    Vendor -&gt;&gt; tea_product: POST to /v1/product to create new product
+    tea_product --&gt;&gt; Vendor: Product is created and TEA Product Identifier (PI) returned
+
+    Vendor -&gt;&gt; tea_component: POST to /v1/component with the TEA PI and component version as the payload
+    tea_component -&gt;&gt; Vendor: Component is created and a TEA Component ID is returned
+
+    Vendor -&gt;&gt; tea_collection: POST to /v1/collection with the TEA Component ID and the artefact as payload
+    tea_collection -&gt;&gt; Vendor: Collection is created with the collection ID returned
+
+</code></pre>
+    </emu-clause>
+    <emu-clause id="sec-flow-publisher-3-release-life-cycle">
+      <h1>Release life cycle</h1> <pre><code>sequenceDiagram
+    autonumber
+    actor Vendor
+    participant tea_product as TEA Product
+    participant tea_component as TEA Component
+    participant tea_collection as TEA Collection
+
+    Note over Vendor,tea_component: Create new release
+
+    Vendor -&gt;&gt; tea_component: POST to /v1/component with the TEA PI and component version as the payload
+    tea_component -&gt;&gt; Vendor: Component is created and a TEA Component ID is returned
+
+    Note over Vendor,TEA Component: Add an artefact (e.g. SBOM)
+    Vendor -&gt;&gt; tea_collection: POST to /v1/collection with the TEA Component ID and the artefact as payload
+    tea_collection -&gt;&gt; Vendor: Collection is created with the collection ID returned
+
+</code></pre>
+    </emu-clause>
+    <emu-clause id="sec-flow-publisher-4-adding-a-new-artefact">
+      <h1>Adding a new artefact</h1> <pre><code>sequenceDiagram
+    autonumber
+    actor Vendor
+    participant tea_product as TEA Product
+    participant tea_component as TEA Component
+    participant tea_collection as TEA Collection
+
+    Vendor -&gt;&gt; tea_component: GET to /v1/component with the TEA PI to get the latest version
+    tea_component -&gt;&gt; Vendor: Component will be returned
+
+    Vendor -&gt;&gt; tea_collection: POST to /v1/collection with the TEA Component ID and the artefact as payload
+    tea_collection -&gt;&gt; Vendor: Collection is created with the collection ID returned
+</code></pre>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:tea-product/tea-product.md -->
+  <emu-clause id="sec-tea-product-1-the-tea-product-api">
+    <h1>The TEA product API</h1>
+    <p>After TEA discovery, the <a href="/discovery/readme.md">Transparency Exchange Identifier (TEI)</a> resolves to a specific TEA Product Release, which represents a concrete, versioned offering. A TEA Product is an optional higher-level object that groups multiple Product Releases for a product line or family and can be browsed via <code>/product/{uuid}/releases</code>.</p>
+    <ul>
+      <li>A product release may consist of a single component, the output will be metadata about the product and the TEA COMPONENT object.</li>
+      <li>For a composed product release consisting of a bundle of components or component releases, the response will be multiple TEA COMPONENT objects.</li>
+    </ul>
+    <p>In addition, all known TEIs for the product will be returned, in order for a TEA client to avoid duplication. This list can also include known Package URLs (PURL) and CPEs for the product.</p>
+    <emu-clause id="sec-tea-product-2-authorization">
+      <h1>Authorization</h1>
+      <p>Authorization can be done on multiple levels, including which products and versions are supported for a specific user.</p>
+    </emu-clause>
+    <emu-clause id="sec-tea-product-3-composite-products">
+      <h1>Composite products</h1>
+      <p>A TEA Product Release will be the starting point of discovery. The TEA product release will list all included components</p>
+      <p>with the UUID of the TEA component. The reference list may also include a UUID of a specific release of a component in the case where a product always includes a single release of the component.</p>
+      <p>The URL can be to a different vendor or different site with the same vendor.</p>
+    </emu-clause>
+    <emu-clause id="sec-tea-product-4-tea-product-object">
+      <h1>TEA Product object</h1>
+      <p>A TEA Product object has the following parts:</p>
+      <ul>
+        <li><strong>uuid</strong>: A unique identifier for the TEA product</li>
+        <li><strong>name</strong>: Product name</li>
+        <li><strong>identifiers</strong>: List of identifiers for the product <ul>
+            <li><strong>idType</strong>: Type of identifier, e.g. <code>tei</code>, <code>purl</code>, <code>cpe</code></li>
+            <li><strong>idValue</strong>: Identifier value</li>
+          </ul>
+        </li>
+        <li><strong>components</strong>: List of TEA components for the product <ul>
+            <li><strong>uuid</strong>: Unique identifier of the TEA component</li>
+            <li><strong>release</strong>: Optional UUID of a TEA component release</li>
+          </ul>
+        </li>
+      </ul>
+      <p>The TEA Component UUID is used in the Component API to find out which versions of the Component that exists.</p>
+      <p>The goal of the TEA Product API is to provide a selection of product versions to assist the user software in finding a match for the owned version.</p>
+      <emu-clause id="sec-tea-product-5-example">
+        <h1>Example</h1>
+        <p>An example of a product consisting of an OSS project and all its Maven artefacts:</p> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;09e8c73b-ac45-4475-acac-33e6a7314e6d&quot;,
+  &quot;name&quot;: &quot;Apache Log4j 2&quot;,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;CPE&quot;,
+      &quot;idValue&quot;: &quot;cpe:2.3:a:apache:log4j&quot;
+    },
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.logging.log4j/log4j-api&quot;
+    },
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.logging.log4j/log4j-core&quot;
+    },
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.logging.log4j/log4j-layout-template-json&quot;
+    }
+  ]
+}
+</code></pre> <p>Releases for this Product can be browsed via the API endpoint <code>/product/{uuid}/releases</code>.</p>
+      </emu-clause>
+      <emu-clause id="sec-tea-product-6-api-usage">
+        <h1>API usage</h1>
+        <p>The user will find this API end point using TEA discovery.</p>
+        <p>A user will approach the API just to discover data before purchase, or with a specific product and product version in scope. The format of the version may follow many syntaxes, so maybe the API needs to be able to provide some sort of format for the version string.</p>
+        <p>An automated system may want to provide the user with a GUI, listing versions and being able to scroll to the next page until the user selects a version.</p>
+      </emu-clause>
+      <emu-clause id="sec-tea-product-7-tea-api-operation">
+        <h1>Tea API operation</h1>
+        <ul>
+          <li>Recommendation: Support HTTP compression</li>
+          <li>Recommendation: HTTP content negotiation <ul>
+              <li>Like &quot;I prefer JSON, but can accept XML&quot;</li>
+            </ul>
+          </li>
+          <li>Pagination support <ul>
+              <li>max per page</li>
+              <li>start page</li>
+              <li>Default value defined</li>
+            </ul>
+          </li>
+        </ul>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:tea-product/tea-product-release.md -->
+  <emu-clause id="sec-tea-product-release-1-tea-product-release">
+    <h1>TEA Product Release</h1>
+    <emu-clause id="sec-tea-product-release-2-overview">
+      <h1>Overview</h1>
+      <p>A TEA Product Release represents a specific versioned release of a TEA Product. It is the primary resolvable entity via TEI and the entry point for discovery of included components and related collections of security artefacts.</p>
+      <p>Key attributes:</p>
+      <ul>
+        <li>uuid: Unique identifier of the product release</li>
+        <li>product: UUID of the TEA Product this release belongs to</li>
+        <li>version: Human-readable version string of the product release</li>
+        <li>createdDate: Timestamp when the product release was created in TEA</li>
+        <li>releaseDate: Upstream product release timestamp</li>
+        <li>preRelease: Indicates pre-release/beta status</li>
+        <li>identifiers: Array of identifiers (idType: CPE/TEI/PURL; idValue: string)</li>
+        <li>components: Array of component references included in this product release <ul>
+            <li>uuid: UUID of the TEA Component</li>
+            <li>release: Optional UUID of a specific component release to pin an exact version</li>
+          </ul>
+        </li>
+      </ul>
+      <p>Collections for a product release contain artefacts relevant to that product release.</p>
+    </emu-clause>
+    <emu-clause id="sec-tea-product-release-3-json-examples">
+      <h1>JSON examples</h1>
+      <p>The following example is reused from the OpenAPI schema (<code>components/schemas/productRelease.examples</code>), ensuring exact field names and casing.</p> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;123e4567-e89b-12d3-a456-426614174000&quot;,
+  &quot;version&quot;: &quot;2.24.3&quot;,
+  &quot;createdDate&quot;: &quot;2025-04-01T15:43:00Z&quot;,
+  &quot;releaseDate&quot;: &quot;2025-04-01T15:43:00Z&quot;,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;TEI&quot;,
+      &quot;idValue&quot;: &quot;tei:vendor:product@2.24.3&quot;
+    }
+  ],
+  &quot;components&quot;: [
+    {
+      &quot;uuid&quot;: &quot;3910e0fd-aff4-48d6-b75f-8bf6b84687f0&quot;
+    },
+    {
+      &quot;uuid&quot;: &quot;b844c9bd-55d6-478c-af59-954a932b6ad3&quot;,
+      &quot;release&quot;: &quot;da89e38e-95e7-44ca-aa7d-f3b6b34c7fab&quot;
+    }
+  ]
+}
+</code></pre> <p>Notes:</p>
+      <ul>
+        <li>Property <code>product</code> exists in the schema and links a product release to its parent product; it may not be present in all examples.</li>
+        <li>Use uppercase idType values exactly as defined by the schema enum: CPE, TEI, PURL.</li>
+      </ul>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:tea-component/tea-component.md -->
+  <emu-clause id="sec-tea-component-1-the-tea-component-api">
+    <h1>The TEA Component API</h1>
+    <p>The TEA Component represents a component lineage. A product release may be constructed with one or multiple TEA Components, each with their own set of releases and related artefacts.</p>
+    <p>Each TEA Component has a list of Component Releases (see <code>/component/{uuid}/releases</code>), which enumerates all known versions for that component.</p>
+    <p>The API should be very agnostic as to how a &quot;version&quot; is indicated - semver, vers, name, hash or anything else.</p>
+    <emu-clause id="sec-tea-component-2-versions-and-teis">
+      <h1>Versions and TEIs</h1>
+      <p>Each product object has one or multiple TEI URNs.</p>
+      <p>For the API to be able to present a list of versions in a cronological order, a timestamp for a release is required.</p>
+    </emu-clause>
+    <emu-clause id="sec-tea-component-3-tea-component-object">
+      <h1>TEA Component Object</h1>
+      <p>A TEA Component object has the following parts:</p>
+      <ul>
+        <li><strong>uuid</strong>: A unique identifier for the TEA component</li>
+        <li><strong>name</strong>: Component name</li>
+        <li><strong>identifiers</strong>: List of identifiers for the component <ul>
+            <li><strong>idType</strong>: Type of identifier, e.g. <code>tei</code>, <code>purl</code>, <code>cpe</code></li>
+            <li><strong>idValue</strong>: Identifier value</li>
+          </ul>
+        </li>
+      </ul>
+      <p>Note: In coming versions, there may be a flag indicating lifecycle status for a component.</p>
+      <emu-clause id="sec-tea-component-4-examples">
+        <h1>Examples</h1>
+        <p>Some examples of Maven artefacts as TEA Components:</p> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;3910e0fd-aff4-48d6-b75f-8bf6b84687f0&quot;,
+  &quot;name&quot;: &quot;Apache Log4j API&quot;,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.logging.log4j/log4j-api&quot;
+    }
+  ]
+}
+</code></pre> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;b844c9bd-55d6-478c-af59-954a932b6ad3&quot;,
+  &quot;name&quot;: &quot;Apache Log4j Core&quot;,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;CPE&quot;,
+      &quot;idValue&quot;: &quot;cpe:2.3:a:apache:log4j&quot;
+    },
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.logging.log4j/log4j-core&quot;
+    }
+  ]
+}
+</code></pre>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-tea-component-5-handling-the-pre-release-flag">
+      <h1>Handling the Pre-Release flag</h1>
+      <p>The &quot;Pre-release&quot; flag is used to indicate that this is not a final release. For a given Component with a UUID, the flag can be set to indicate a &quot;test&quot;, &quot;beta&quot;, &quot;alpha&quot; or similar non-deployed release. It can only be set when creating the Component. The TEA implementation may allow it to be unset (False) once. This is to support situations where a object is promoted as is after testing to production version. The flag can not be set after initial creation and publication of the Component.</p>
+      <p>If the final version is different from the pre-release (bugs fixed, code changed, different binary) a new Component with a new UUID and version needs to be created.</p>
+    </emu-clause>
+    <emu-clause id="sec-tea-component-6-references">
+      <h1>References</h1>
+      <ul>
+        <li>Semantic versioning (Semver): <a href="https://semver.org">https://semver.org</a></li>
+        <li>PURL VERS <a href="https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst">https://github.com/package-url/purl-spec/blob/master/VERSION-RANGE-SPEC.rst</a></li>
+      </ul>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:tea-component/tea-release.md -->
+  <emu-clause id="sec-tea-release-1-tea-component-release">
+    <h1>TEA Component Release</h1>
+    <emu-clause id="sec-tea-release-2-overview">
+      <h1>Overview</h1>
+      <p>A TEA Component Release represents a specific version of a TEA Component lineage. It is the concrete, versioned entity which has collections of security-related artefacts (SBOM, VDR/VEX, attestations, etc.).</p>
+      <p>Key attributes:</p>
+      <ul>
+        <li>uuid: Unique identifier of the component release</li>
+        <li>component: UUID of the TEA Component this release belongs to</li>
+        <li>version: Human-readable version string</li>
+        <li>createdDate: Timestamp when the release was created in TEA</li>
+        <li>releaseDate: Upstream release timestamp</li>
+        <li>preRelease: Indicates pre-release/beta status</li>
+        <li>identifiers: Array of identifiers (idType: CPE/TEI/PURL; idValue: string)</li>
+      </ul>
+      <p>Collections for a release contain artefacts relevant to that specific release.</p>
+    </emu-clause>
+    <emu-clause id="sec-tea-release-3-json-examples">
+      <h1>JSON examples</h1>
+      <p>The following examples are reused from the OpenAPI schema (<code>components/schemas/release.examples</code>), ensuring exact field names and casing.</p> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;605d0ecb-1057-40e4-9abf-c400b10f0345&quot;,
+  &quot;version&quot;: &quot;11.0.6&quot;,
+  &quot;createdDate&quot;: &quot;2025-04-01T15:43:00Z&quot;,
+  &quot;releaseDate&quot;: &quot;2025-04-01T15:43:00Z&quot;,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.6&quot;
+    }
+  ]
+}
+</code></pre> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;da89e38e-95e7-44ca-aa7d-f3b6b34c7fab&quot;,
+  &quot;version&quot;: &quot;10.1.40&quot;,
+  &quot;createdDate&quot;: &quot;2025-04-01T18:20:00Z&quot;,
+  &quot;releaseDate&quot;: &quot;2025-04-01T18:20:00Z&quot;,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@10.1.40&quot;
+    }
+  ]
+}
+</code></pre> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;95f481df-f760-47f4-b2f2-f8b76d858450&quot;,
+  &quot;version&quot;: &quot;11.0.0-M26&quot;,
+  &quot;createdDate&quot;: &quot;2024-09-13T17:49:00Z&quot;,
+  &quot;preRelease&quot;: true,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26&quot;
+    }
+  ]
+}
+</code></pre> <p>Notes:</p>
+      <ul>
+        <li>Use uppercase idType values exactly as defined by the schema enum: CPE, TEI, PURL.</li>
+      </ul>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:tea-collection/tea-collection.md -->
+  <emu-clause id="sec-tea-collection-1-tea-releases-and-collections">
+    <h1>TEA Releases and Collections</h1>
+    <emu-clause id="sec-tea-collection-2-the-tea-component-release-object-tro">
+      <h1>The TEA Component Release object (TRO)</h1>
+      <p>A TEA Component Release object represents a specific version of a component, identified by a unique version number and associated metadata. Each release may include multiple distributions, which capture variations such as architecture, packaging, or localization.</p>
+      <ul>
+        <li>For software components, each distribution typically corresponds to a different digital file delivered to users (e.g., by platform or packaging type).</li>
+        <li>For hardware components, distributions may reflect differences in packaging, language, or other physical attributes.</li>
+      </ul>
+      <p>Each distribution is assigned a unique <code>distributionType</code>, defined by the producer, which is used to associate relevant TEA Artifacts with that distribution. Since TEA Artifacts can be associated with multiple release objects, the taxonomy for <code>distributionType</code> values should be defined on a TEA service level and consistently applied to all TEA Artifacts published by that producer. This ensures global uniqueness and reliable association across releases.</p>
+      <p>The <code>uuid</code> of the TEA Component Release object is identical to the <code>uuid</code> of its associated <a href="#the-tea-collection-object-tco">TEA Collection object (TCO)</a>.</p>
+      <emu-clause id="sec-tea-collection-3-structure">
+        <h1>Structure</h1>
+        <p>A TEA Component Release object contains the following fields:</p>
+        <ul>
+          <li><strong>uuid</strong>: Unique identifier for the TEA Component Release.</li>
+          <li><strong>version</strong>: Version number of the release.</li>
+          <li><strong>createdDate</strong>: Timestamp when the release object was created.</li>
+          <li><strong>releaseDate</strong>: Timestamp of the actual release.</li>
+          <li><strong>preRelease</strong>: Boolean flag indicating if this is a pre-release (e.g., beta). This flag can be disabled after creation, but not enabled.</li>
+          <li><strong>identifiers</strong>: List of identifiers for the component.</li>
+          <li><strong>idType</strong>: Type of identifier (e.g., <code>TEI</code>, <code>PURL</code>, <code>CPE</code>).</li>
+          <li><strong>idValue</strong>: Value of the identifier.</li>
+          <li><strong>distributions</strong>: List of release distributions, each with: <ul>
+              <li><strong>distributionType</strong>: Unique identifier for the distribution type.</li>
+              <li><strong>description</strong>: Free-text description of the distribution.</li>
+              <li><strong>identifiers</strong>: List of identifiers specific to this distribution.</li>
+              <li><strong>idType</strong>: Type of identifier (e.g., <code>TEI</code>, <code>PURL</code>, <code>CPE</code>).</li>
+              <li><strong>idValue</strong>: Value of the identifier.</li>
+              <li><strong>url</strong>: Direct download URL for the distribution.</li>
+              <li><strong>signatureUrl</strong>: Direct download URL for the distribution's external signature.</li>
+              <li><strong>checksums</strong>: List of checksums for the distribution. <ul>
+                  <li><strong>algType</strong>: Checksum algorithm used.</li>
+                  <li><strong>algValue</strong>: Checksum value.</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </emu-clause>
+      <emu-clause id="sec-tea-collection-4-examples">
+        <h1>Examples</h1>
+        <emu-clause id="sec-tea-collection-5-single-distribution">
+          <h1>Single distribution</h1>
+          <p>This example shows a TEA Component Release for Apache Log4j Core, which is distributed as a single JAR file. Even though there is only one distribution, the <code>distributions</code> attribute is included to enable searching for the release by the SHA-256 checksum of the JAR. This structure also allows for future extensibility if additional distributions are introduced.</p>
+          <details>
+            <summary>Example of simple release</summary> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;b1e2c3d4-5678-49ab-9cde-123456789abc&quot;,
+  &quot;version&quot;: &quot;2.24.3&quot;,
+  &quot;createdDate&quot;: &quot;2024-12-10T10:51:00Z&quot;,
+  &quot;releaseDate&quot;: &quot;2024-12-13T12:52:29Z&quot;,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3&quot;
+    }
+  ],
+  &quot;distributions&quot;: [
+    {
+      &quot;distributionType&quot;: &quot;jar&quot;,
+      &quot;description&quot;: &quot;Binary distribution&quot;,
+      &quot;identifiers&quot;: [
+        {
+          &quot;idType&quot;: &quot;PURL&quot;,
+          &quot;idValue&quot;: &quot;pkg:maven/org.apache.logging.log4j/log4j-core@2.24.3?type=jar&quot;
+        }
+      ],
+      &quot;checksums&quot;: [
+        {
+          &quot;algType&quot;: &quot;SHA-256&quot;,
+          &quot;algValue&quot;: &quot;b1e2c3d4f5a67890b1e2c3d4f5a67890b1e2c3d4f5a67890b1e2c3d4f5a67890&quot;
+        }
+      ],
+      &quot;url&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3.jar&quot;,
+      &quot;signatureUrl&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3.jar.asc&quot;
+    }
+  ]
+}
+</code></pre>
+          </details>
+        </emu-clause>
+        <emu-clause id="sec-tea-collection-6-multiple-distributions">
+          <h1>Multiple distributions</h1>
+          <p>This is an example of a TEA Component Release for Apache Tomcat 11.0.7 binary distributions. The example defines four distinct <code>distributionType</code>s, which is essential not only for associating the correct SBOMs with each distribution, but also for accurately tracking and reporting vulnerabilities that may affect only specific distributions. For instance:</p>
+          <ul>
+            <li>The <code>zip</code> and <code>tar.gz</code> distributions contain only Java JARs.</li>
+            <li>The <code>windows-x64.zip</code> distribution additionally includes the <a href="https://commons.apache.org/proper/commons-daemon/procrun.html">Apache Procrun</a> binary, which is specific to Windows and may introduce unique vulnerabilities.</li>
+            <li>The <code>windows-x64.exe</code> distribution contains the same data as <code>windows-x64.zip</code>, but is packaged as a self-extracting installer created by the <a href="https://nsis.sourceforge.io/Main_Page">Nullsoft Scriptable Install System</a>.</li>
+          </ul>
+          <p>By defining separate <code>distributionType</code>s, it becomes possible to precisely associate artefacts and vulnerability disclosures with the affected distributions, ensuring accurate risk assessment and remediation.</p>
+          <details>
+            <summary>Example of four different binary distributions in the same release</summary> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;605d0ecb-1057-40e4-9abf-c400b10f0345&quot;,
+  &quot;version&quot;: &quot;11.0.7&quot;,
+  &quot;createdDate&quot;: &quot;2025-05-07T18:08:00Z&quot;,
+  &quot;releaseDate&quot;: &quot;2025-05-12T18:08:00Z&quot;,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.7&quot;
+    }
+  ],
+  &quot;distributions&quot;: [
+    {
+      &quot;distributionType&quot;: &quot;zip&quot;,
+      &quot;description&quot;: &quot;Core binary distribution, zip archive&quot;,
+      &quot;identifiers&quot;: [
+        {
+          &quot;idType&quot;: &quot;PURL&quot;,
+          &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.7?type=zip&quot;
+        }
+      ],
+      &quot;checksums&quot;: [
+        {
+          &quot;algType&quot;: &quot;SHA_256&quot;,
+          &quot;algValue&quot;: &quot;9da736a1cdd27231e70187cbc67398d29ca0b714f885e7032da9f1fb247693c1&quot;
+        }
+      ],
+      &quot;url&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.zip&quot;,
+      &quot;signatureUrl&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.zip.asc&quot;
+    },
+    {
+      &quot;distributionType&quot;: &quot;tar.gz&quot;,
+      &quot;description&quot;: &quot;Core binary distribution, tar.gz archive&quot;,
+      &quot;identifiers&quot;: [
+        {
+          &quot;idType&quot;: &quot;PURL&quot;,
+          &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.7?type=tar.gz&quot;
+        }
+      ],
+      &quot;checksums&quot;: [
+        {
+          &quot;algType&quot;: &quot;SHA_256&quot;,
+          &quot;algValue&quot;: &quot;2fcece641c62ba1f28e1d7b257493151fc44f161fb391015ee6a95fa71632fb9&quot;
+        }
+      ],
+      &quot;url&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.tar.gz&quot;,
+      &quot;signatureUrl&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.tar.gz.asc&quot;
+    },
+    {
+      &quot;distributionType&quot;: &quot;windows-x64.zip&quot;,
+      &quot;description&quot;: &quot;Core binary distribution, Windows x64 zip archive&quot;,
+      &quot;identifiers&quot;: [
+        {
+          &quot;idType&quot;: &quot;PURL&quot;,
+          &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.7?classifier=windows-x64&amp;type=zip&quot;
+        }
+      ],
+      &quot;checksums&quot;: [
+        {
+          &quot;algType&quot;: &quot;SHA_256&quot;,
+          &quot;algValue&quot;: &quot;62a5c358d87a8ef21d7ec1b3b63c9bbb577453dda9c00cbb522b16cee6c23fc4&quot;
+        }
+      ],
+      &quot;url&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7-windows-x64.zip&quot;,
+      &quot;signatureUrl&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7.zip.asc&quot;
+    },
+    {
+      &quot;distributionType&quot;: &quot;windows-x64.exe&quot;,
+      &quot;description&quot;: &quot;Core binary distribution, Windows Service Installer (MSI)&quot;,
+      &quot;checksums&quot;: [
+        {
+          &quot;algType&quot;: &quot;SHA_512&quot;,
+          &quot;algValue&quot;: &quot;1d3824e7643c8aba455ab0bd9e67b14a60f2aaa6aa7775116bce40eb0579e8ced162a4f828051d3b867e96ee2858ec5da0cc654e83a83ba30823cbea0df4ff96&quot;
+        }
+      ],
+      &quot;url&quot;: &quot;https://dlcdn.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe&quot;,
+      &quot;signatureUrl&quot;: &quot;https://downloads.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe.asc&quot;
+    }
+  ]
+}
+</code></pre>
+          </details>
+        </emu-clause>
+        <emu-clause id="sec-tea-collection-7-pre-release-flag-usage">
+          <h1>Pre-release flag usage</h1>
+          <p>The <code>preRelease</code> flag is used to indicate that a release is not production ready, regardless of the version naming scheme. This helps consumers identify non-production releases without relying on conventions like <code>-beta</code>, <code>-rc</code>, or <code>-M</code> in the version string.</p>
+          <p>There are two main scenarios for using the <code>preRelease</code> flag:</p>
+          <ul>
+            <li><strong>Pending release:</strong> The distribution is still undergoing quality assurance or review and is not yet officially released. These typically lack a <code>releaseDate</code> attribute. Once the release is approved, the <code>preRelease</code> flag is set to <code>false</code> and the <code>releaseDate</code> is added.</li>
+            <li><strong>Permanent pre-release:</strong> The distribution is intentionally marked as a pre-release (e.g., beta, milestone, or release candidate) and will never be considered production ready, even after all checks are complete. These may have a <code>releaseDate</code>, but <code>preRelease</code> remains <code>true</code>.</li>
+          </ul>
+          <details>
+            <summary>Examples of non-production ready distributions</summary>
+            <ul>
+              <li><strong>Pending release (no <code>releaseDate</code>):</strong><pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;e2a1c7b4-3f2d-4e8a-9c1a-7b2e4d5f6a8b&quot;,
+  &quot;version&quot;: &quot;11.0.0&quot;,
+  &quot;createdDate&quot;: &quot;2025-09-01T00:00:00Z&quot;,
+  &quot;preRelease&quot;: true,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.0?repository_url=https:%2F%2Frepository.apache.org%2Fcontent%2Fgroups%2Fstaging%2F&quot;
+    }
+  ]
+}
+</code></pre> </li>
+              <li><strong>Transition to production-ready (<code>preRelease</code> flag turned off, <code>releaseDate</code> added)</strong>:<pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;e2a1c7b4-3f2d-4e8a-9c1a-7b2e4d5f6a8b&quot;,
+  &quot;version&quot;: &quot;11.0.0&quot;,
+  &quot;createdDate&quot;: &quot;2025-09-01T00:00:00Z&quot;,
+  &quot;releaseDate&quot;: &quot;2025-09-10T12:00:00Z&quot;,
+  &quot;preRelease&quot;: false,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.0&quot;
+    }
+  ]
+}
+</code></pre> </li>
+              <li><strong>Beta version (has <code>releaseDate</code>, but not production ready)</strong>:<pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;95f481df-f760-47f4-b2f2-f8b76d858450&quot;,
+  &quot;version&quot;: &quot;11.0.0-M26&quot;,
+  &quot;createdDate&quot;: &quot;2024-09-13T17:49:00Z&quot;,
+  &quot;releaseDate&quot;: &quot;2024-09-16T17:49:00Z&quot;,
+  &quot;preRelease&quot;: true,
+  &quot;identifiers&quot;: [
+    {
+      &quot;idType&quot;: &quot;PURL&quot;,
+      &quot;idValue&quot;: &quot;pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26&quot;
+    }
+  ]
+}
+</code></pre> </li>
+            </ul>
+          </details>
+        </emu-clause>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-tea-collection-8-tea-collection-object-tco">
+      <h1>TEA Collection object (TCO)</h1>
+      <p>For each product and version there is a Tea Collection object, which is a list of available artefacts for this specific version. The TEA Index is a list of TEA collections.</p>
+      <p>The TEA collection is normally created by the TEA application server at publication time of artefacts. The publisher may sign the collection object as a JSON file at time of publication.</p>
+      <p>If there are any updates of artefacts within a collection for the same version of a product, then a new TEA Collection object is created and signed. This update will have the same UUID, but a new version number. A reason for the update will have to be provided. This shall be used to correct mistakes, spelling errors as well as to provide new information on dynamic artefact types such as LCE or VEX. If the product is modified, that is a new product version and that should generate a new collection object with a new UUID and updated metadata.</p>
+      <p>The API allows for retrieving the latest version of the collection, or a specific version.</p>
+      <emu-clause id="sec-tea-collection-9-dynamic-or-static-collection-objects">
+        <h1>Dynamic or static Collection objects</h1>
+        <p>The TCO is produced by the TEA software platform. There are two ways to implement this:</p>
+        <ul>
+          <li><strong>Dynamic</strong>: The TCO is built for each API request and created dynamically.</li>
+          <li><strong>Static</strong>: The TCO is built at publication time as a static object by the publisher. This object can be digitally signed at publication time and version controlled.</li>
+        </ul>
+      </emu-clause>
+      <emu-clause id="sec-tea-collection-10-collection-object">
+        <h1>Collection object</h1>
+        <p>The TEA Collection object has the following parts:</p>
+        <ul>
+          <li>Preamble</li>
+          <li><strong>uuid</strong>: UUID of the TEA Collection object. Note that this is equal to the UUID of the associated TEA Component Release object. When updating a collection, only the <code>version</code> is changed.</li>
+          <li><strong>version</strong>: TEA Collection version, incremented each time its content changes. Versions start with 1.</li>
+          <li><strong>date</strong>: TEA Collection version release date.</li>
+          <li><strong>belongsTo</strong>: Scope of the collection; enum values <code>RELEASE</code> or <code>PRODUCT_RELEASE</code>.</li>
+          <li><strong>updateReason</strong>: Reason for the update/release of the TEA Collection object. <ul>
+              <li><strong>type</strong>: Type of update reason. See <a href="#the-reason-for-tco-update-enum">reasons for TEA Collection update</a> below.</li>
+              <li><strong>comment</strong>: Free text description.</li>
+            </ul>
+          </li>
+          <li></li>
+          <li><strong>artifacts</strong>: List of TEA Artifact objects. See <a href="#tea-artifact-object">below</a>.</li>
+        </ul>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-tea-collection-11-tea-artifact-object">
+      <h1>TEA Artifact object</h1>
+      <p>A TEA Artifact object represents a security-related document or file linked to a component release, such as an SBOM, VEX, attestation, or license. TEA Artifacts are strictly <strong>immutable</strong>: if the underlying document changes, a new TEA Artifact object must be created. URLs referenced in this object must always resolve to the same resource to ensure that published checksums remain valid and verifiable.</p>
+      <p>TEA Artifacts can be reused across multiple TEA Collections, allowing the same document to be referenced by different component or product releases. This promotes consistency and reduces duplication.</p>
+      <p>Optionally, each TEA Artifact can specify the <code>distributionType</code> identifiers of the distributions it applies to. If this field is absent, the TEA Artifact is considered applicable to all distributions of the release.</p>
+      <emu-clause id="sec-tea-collection-12-structure">
+        <h1>Structure</h1>
+        <p>A TEA Artifact object contains the following fields:</p>
+        <ul>
+          <li><strong>uuid</strong>: The UUID of the TEA Artifact object. Together with <em>version</em> uniquely identifies the TEA Artifact.</li>
+          <li><strong>version</strong>: An integer with default value 1. Together with <em>uuid</em> uniquely identifies the TEA Artifact. This field can be used to designate successive, immutable revisions of an artefact content (e.g. an updated VEX file).</li>
+          <li><strong>name</strong>: A human-readable name for the artefact.</li>
+          <li><strong>type</strong>: The type of artefact. See <a href="#tea-artefact-types">TEA Artifact types</a> for allowed values (e.g., <code>BOM</code>, <code>VULNERABILITIES</code>, <code>LICENSE</code>).</li>
+          <li><strong>createdDate</strong>: The date and time the TEA Artefact revision was created.</li>
+          <li><strong>componentDistributions</strong> (optional):<br> An array of <code>distributionType</code> identifiers indicating which distributions this TEA Artifact applies to. If omitted, the TEA Artifact applies to all distributions.</li>
+          <li><strong>formats</strong>:<br> An array of objects, each representing the same artefact content in a different format. The order of the list is not significant. Each format object includes: <ul>
+              <li><strong>mediaType</strong>: The MIME type of the document (e.g., <code>application/vnd.cyclonedx+xml</code>).</li>
+              <li><strong>description</strong>: A free-text description of the artefact format.</li>
+              <li><strong>url</strong>: A direct download URL for the artefact. This must point to an immutable resource.</li>
+              <li><strong>signatureUrl</strong> (optional): A direct download URL for a detached digital signature of the artefact, if available.</li>
+              <li><strong>checksums</strong>:<br> An array of checksum objects for the artefact, each containing: <ul>
+                  <li><strong>algType</strong>: The checksum algorithm used (e.g., <code>SHA_256</code>, <code>SHA3_512</code>).</li>
+                  <li><strong>algValue</strong>: The checksum value as a string.</li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+      </emu-clause>
+      <emu-clause id="sec-tea-collection-13-notes">
+        <h1>Notes</h1>
+        <ul>
+          <li>The <code>formats</code> array allows the same artefact to be provided in multiple encodings or serializations (e.g., JSON, XML).</li>
+          <li>The <code>checksums</code> field provides integrity verification for each artefact format.</li>
+          <li>The <code>signatureUrl</code> enables consumers to verify the authenticity of the artefact using detached signatures.</li>
+          <li>Artefacts should be published to stable, versioned URLs to ensure immutability and traceability.</li>
+        </ul>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-tea-collection-14-the-reason-for-tco-update-enum">
+      <h1>The reason for TCO update enum</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>ENUM</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>INITIAL_RELEASE</td>
+            <td>Initial release of the collection</td>
+          </tr>
+          <tr>
+            <td>VEX_UPDATED</td>
+            <td>Updated the VEX artefact(s)</td>
+          </tr>
+          <tr>
+            <td>ARTIFACT_UPDATED</td>
+            <td>Updated the artefact(s) other than VEX</td>
+          </tr>
+          <tr>
+            <td>ARTIFACT_REMOVED</td>
+            <td>Removal of artefact</td>
+          </tr>
+          <tr>
+            <td>ARTIFACT_ADDED</td>
+            <td>Addition of an artefact</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Updates of VEX (CSAF) files may be handled in a different way by a TEA client, producing different alerts than other changes of a collection.</p>
+    </emu-clause>
+    <emu-clause id="sec-tea-collection-15-tea-artifact-types">
+      <h1>TEA Artifact types</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>ENUM</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>ATTESTATION</td>
+            <td>Machine-readable statements containing facts, evidence, or testimony.</td>
+          </tr>
+          <tr>
+            <td>BOM</td>
+            <td>Bill of Materials: SBOM, OBOM, HBOM, SaaSBOM, etc.</td>
+          </tr>
+          <tr>
+            <td>BUILD_META</td>
+            <td>Build-system specific metadata file: <code>pom.xml</code>, <code>package.json</code>, <code>.nuspec</code>, etc.</td>
+          </tr>
+          <tr>
+            <td>CERTIFICATION</td>
+            <td>Industry, regulatory, or other certification from an accredited certification body.</td>
+          </tr>
+          <tr>
+            <td>FORMULATION</td>
+            <td>Describes how a component or service was manufactured or deployed.</td>
+          </tr>
+          <tr>
+            <td>LICENSE</td>
+            <td>License file</td>
+          </tr>
+          <tr>
+            <td>RELEASE_NOTES</td>
+            <td>Release notes document</td>
+          </tr>
+          <tr>
+            <td>SECURITY_TXT</td>
+            <td>A <code>security.txt</code> file</td>
+          </tr>
+          <tr>
+            <td>THREAT_MODEL</td>
+            <td>A threat model</td>
+          </tr>
+          <tr>
+            <td>VULNERABILITIES</td>
+            <td>A list of vulnerabilities: VDR/VEX</td>
+          </tr>
+          <tr>
+            <td>OTHER</td>
+            <td>Document that does not fall into any of the above categories</td>
+          </tr>
+        </tbody>
+      </table>
+      <emu-clause id="sec-tea-collection-16-examples">
+        <h1>Examples</h1> <pre><code class="language-json">{
+  &quot;uuid&quot;: &quot;4c72fe22-9d83-4c2f-8eba-d6db484f32c8&quot;,
+  &quot;version&quot;: 10,
+  &quot;date&quot;: &quot;2024-12-13T00:00:00Z&quot;,
+  &quot;updateReason&quot;: {
+    &quot;type&quot;: &quot;ARTIFACT_UPDATED&quot;,
+    &quot;comment&quot;: &quot;VDR file updated&quot;
+  },
+  &quot;artifacts&quot;: [
+    {
+      &quot;uuid&quot;: &quot;1cb47b95-8bf8-3bad-a5a4-0d54d86e10ce&quot;,
+      &quot;name&quot;: &quot;Build SBOM&quot;,
+      &quot;type&quot;: &quot;BOM&quot;,
+      &quot;formats&quot;: [
+        {
+          &quot;mediaType&quot;: &quot;application/vnd.cyclonedx+xml&quot;,
+          &quot;description&quot;: &quot;CycloneDX SBOM (XML)&quot;,
+          &quot;url&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml&quot;,
+          &quot;signatureUrl&quot;: &quot;https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc&quot;,
+          &quot;checksums&quot;: [
+            {
+              &quot;algType&quot;: &quot;MD5&quot;,
+              &quot;algValue&quot;: &quot;2e1a525afc81b0a8ecff114b8b743de9&quot;
+            },
+            {
+              &quot;algType&quot;: &quot;SHA-1&quot;,
+              &quot;algValue&quot;: &quot;5a7d4caef63c5c5ccdf07c39337323529eb5a770&quot;
+            }
+          ]
+        }
+      ]
+    },
+    {
+      &quot;uuid&quot;: &quot;dfa35519-9734-4259-bba1-3e825cf4be06&quot;,
+      &quot;version&quot;: 7,
+      &quot;name&quot;: &quot;Vulnerability Disclosure Report&quot;,
+      &quot;type&quot;: &quot;VULNERABILITIES&quot;,
+      &quot;formats&quot;: [
+        {
+          &quot;mediaType&quot;: &quot;application/vnd.cyclonedx+xml&quot;,
+          &quot;description&quot;: &quot;CycloneDX VDR (XML)&quot;,
+          &quot;url&quot;: &quot;https://logging.apache.org/cyclonedx/vdr.xml&quot;,
+          &quot;checksums&quot;: [
+            {
+              &quot;algType&quot;: &quot;SHA-256&quot;,
+              &quot;algValue&quot;: &quot;75b81020b3917cb682b1a7605ade431e062f7a4c01a412f0b87543b6e995ad2a&quot;
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+</code></pre>
+      </emu-clause>
+    </emu-clause>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:tea-artifact/tea-artifact.md -->
+  <emu-clause id="sec-tea-artifact-1-known-types">
+    <h1>Known types</h1>
+    <p>meta:enum:</p>
+    <ul>
+      <li>vcs: Version Control System</li>
+      <li>issue-tracker: Issue or defect tracking system, or an Application Lifecycle Management (ALM) system</li>
+      <li>website: Website</li>
+      <li>advisories: Security advisories</li>
+      <li>bom: Bill of Materials (SBOM, OBOM, HBOM, SaaSBOM, etc)</li>
+      <li>mailing-list: Mailing list or discussion group</li>
+      <li>social: Social media account</li>
+      <li>chat: Real-time chat platform</li>
+      <li>documentation: Documentation, guides, or how-to instructions</li>
+      <li>support: Community or commercial support</li>
+      <li>source-distribution: description: The location where the source code distributable can be obtained. This is often an archive format such as zip or tgz. The source-distribution type complements use of the version control (vcs) type.</li>
+      <li>distribution: Direct or repository download location</li>
+      <li>distribution-intake: The location where a component was published to. This is often the same as &quot;distribution&quot; but may also include specialized publishing processes that act as an intermediary.</li>
+      <li>license: The reference to the license file. If a license URL has been defined in the license node, it should also be defined as an external reference for completeness.</li>
+      <li>build-meta: Build-system specific meta file (i.e. pom.xml, package.json, .nuspec, etc)</li>
+      <li>build-system: Reference to an automated build system</li>
+      <li>release-notes: Reference to release notes</li>
+      <li>security-contact: Specifies a way to contact the maintainer, supplier, or provider in the event of a security incident. Common URIs include links to a disclosure procedure, a mailto (RFC-2368) that specifies an email address, a tel (RFC-3966) that specifies a phone number, or dns (RFC-4501) that specifies the records containing DNS Security TXT.</li>
+      <li>model-card: A model card describes the intended uses of a machine learning model, potential limitations, biases, ethical considerations, training parameters, datasets used to train the model, performance metrics, and other relevant data useful for ML transparency.</li>
+      <li>log: A record of events that occurred in a computer system or application, such as problems, errors, or information on current operations. configuration: Parameters or settings that may be used by other components or services.</li>
+      <li>evidence: Information used to substantiate a claim.</li>
+      <li>formulation: Describes how a component or service was manufactured or deployed.</li>
+      <li>attestation: Human or machine-readable statements containing facts, evidence, or testimony.</li>
+      <li>threat-model: An enumeration of identified weaknesses, threats, and countermeasures, dataflow diagram (DFD), attack tree, and other supporting documentation in human-readable or machine-readable format.</li>
+      <li>adversary-model: The defined assumptions, goals, and capabilities of an adversary.</li>
+      <li>risk-assessment: Identifies and analyzes the potential of future events that may negatively impact individuals, assets, and/or the environment. Risk assessments may also include judgments on the tolerability of each risk.</li>
+      <li>vulnerability-assertion: A Vulnerability Disclosure Report (VDR) which asserts the known and previously unknown vulnerabilities that affect a component, service, or product including the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on a component, service, or product.</li>
+      <li>exploitability-statement: A Vulnerability Exploitability eXchange (VEX) which asserts the known vulnerabilities that do not affect a product, product family, or organization, and optionally the ones that do. The VEX should include the analysis and findings describing the impact (or lack of impact) that the reported vulnerability has on the product, product family, or organization.</li>
+      <li>pentest-report: Results from an authorized simulated cyberattack on a component or service, otherwise known as a penetration test.</li>
+      <li>static-analysis-report: SARIF or proprietary machine or human-readable report for which static analysis has identified code quality, security, and other potential issues with the source code.</li>
+      <li>dynamic-analysis-report: Dynamic analysis report that has identified issues such as vulnerabilities and misconfigurations.</li>
+      <li>runtime-analysis-report: Report generated by analyzing the call stack of a running application.</li>
+      <li>component-analysis-report: Report generated by Software Composition Analysis (SCA), container analysis, or other forms of component analysis.</li>
+      <li>maturity-report: Report containing a formal assessment of an organization, business unit, or team against a maturity model.</li>
+      <li>certification-report: Industry, regulatory, or other certification from an accredited (if applicable) certification body.</li>
+      <li>codified-infrastructure: Code or configuration that defines and provisions virtualized infrastructure, commonly referred to as Infrastructure as Code (IaC).</li>
+      <li>quality-metrics: Report or system in which quality metrics can be obtained.</li>
+      <li>poam: Plans of Action and Milestones (POAM) complement an &quot;attestation&quot; external reference. POAM is defined by NIST as a &quot;document that identifies tasks needing to be accomplished. It details resources required to accomplish the elements of the plan, any milestones in meeting the tasks and scheduled completion dates for the milestones&quot;.</li>
+      <li>electronic-signature: An e-signature is commonly a scanned representation of a written signature or a stylized script of the person's name.</li>
+      <li>digital-signature: A signature that leverages cryptography, typically public/private key pairs, which provides strong authenticity verification.</li>
+      <li>rfc-9116: Document that complies with RFC-9116 (A File Format to Aid in Security Vulnerability Disclosure)</li>
+      <li>other: Use this if no other types accurately describe the purpose of the external reference.</li>
+    </ul>
+  </emu-clause>
+  <!-- imported from CycloneDX/transparency-exchange-api@main:signatures/signature.md -->
+  <emu-clause id="sec-signatures-1-transparency-exchange-api-trusting-digital-signatures-in-tea">
+    <h1>Transparency Exchange API - Trusting digital signatures in TEA</h1>
+    <p>Software transparency requires a trust platform so that users can validate the information and artefacts published. Given the situation today any information published is better than none, so the framework for digital signatures will not be mandatory for API compliance. Implementations may require all published information to be signed and validated. In some vertical markets branch standards may require digital signatures.</p>
+    <p>Within the TEA API documents may be signed with an electronic signature. CycloneDX Documents support <a href="https://cyclonedx.org/use-cases/#authenticity">signatures</a> within the JSON and XML files, but other artefacts may need external signature files, a detached signature.</p>
+    <emu-clause id="sec-signatures-2-requirements">
+      <h1>Requirements</h1>
+      <p>Digital signatures provide integrity and identity to published data.</p>
+      <ul>
+        <li><strong>Integrity</strong>: Documents dowloaded must be the same as documents published</li>
+        <li><strong>Identity</strong>: Customers need to be able to verify the publisher of the documents and verify that it is the expected publisher. A TEA server may want to verify that published documents are signed by the expected publisher and that signatures are valid.</li>
+      </ul>
+      <p>In order to sign an object, a pair of asymmetric keys will be needed. The public key is used to create a certificate, signed by a certificate authority (CA). The private key is used for signing and needs to be protected.</p>
+      <p>A software publisher may buy CA services from a commercial vendor or set up an internal PKI solution. The issue with internal PKIs is that external parties do not automatically trust that internal PKI.</p>
+      <p>This document outlines a proposal on how to build that trust and make it possible for publishers to use an internal PKI. It is of course important that this PKI is maintained according to best current practise.</p>
+    </emu-clause>
+    <emu-clause id="sec-signatures-3-api-trust">
+      <h1>API trust</h1>
+      <p>The TEA API is built on the HTTP protocol with TLS encryption and authentication, using the <code>https://</code> URL scheme.</p>
+      <p>The TLS server certificate is normally issued by a public Certificate Authority that is part of the Web PKI. The client needs to validate the TLS server certificate to make sure</p>
+      <ul>
+        <li>that the certificate name (CN or Subject Alt Name) matches the host part of the URI.</li>
+        <li>that the certificate is valid, i.e. the not-before date and the not-after date is not out of range</li>
+        <li>that the certificate is signed by a trusted CA</li>
+      </ul>
+      <p>If the certificate validates properly, the API can be trusted. Validation proves that the server is the right server for the given host name in the URL.</p>
+      <p>This trust can be used to implement trust in a private PKI used to sign documents delivered over the API.</p>
+      <p>In addition, trust anchors can be published in DNSsec as an extra level of validation.</p>
+    </emu-clause>
+    <emu-clause id="sec-signatures-4-getting-trust-anchors">
+      <h1>Getting trust anchors</h1>
+      <p>Much like the EST protocol, the TEA protocol can be used to download trust anchors for a private PKI. These are PEM-encoded certificates in one single text file.</p>
+      <p>The TEA API has a <code>/trust-anchors/</code> API that will download the current trust anchor APIs. This file is not signed, that would cause a chicken-and-egg problem. The certificates in the file are all signed.</p>
+      <p>An implementation should download these and apply them only for this service, not in global scope. A PKI valid for <a href="http://example.com">example.com</a> is not valid for <a href="http://example.net">example.net</a>.</p>
+      <p>Note that the TEA api can host many years of documents for published versions. Old and expired trust anchors may be needed to validate digital signatures on old documents.</p>
+    </emu-clause>
+    <emu-clause id="sec-signatures-5-validating-the-trust-anchors-using-dnssec-dane">
+      <h1>Validating the trust anchors using DNSsec (DANE)</h1>
+    </emu-clause>
+    <emu-clause id="sec-signatures-6-digital-signatures">
+      <h1>Digital signatures</h1>
+      <emu-clause id="sec-signatures-7-digital-signatures-as-specified-for-cyclonedx">
+        <h1>Digital signatures as specified for CycloneDX</h1>
+        <blockquote>
+          <p>&quot;Digital signatures may be applied to a BOM or to an assembly within a BOM. CycloneDX supports XML Signature, JSON Web Signature (JWS), and JSON Signature Format (JSF). Signed BOMs benefit by providing advanced integrity and non-repudiation capabilities.&quot; <a href="https://cyclonedx.org/use-cases/#authenticity">https://cyclonedx.org/use-cases/#authenticity</a></p>
+        </blockquote>
+      </emu-clause>
+      <emu-clause id="sec-signatures-8-external-detached-digital-signatures-for-other-documents">
+        <h1>External (detached) digital signatures for other documents</h1>
+        <ul>
+          <li>indication of hash algorithm</li>
+          <li>indicator of cert used</li>
+          <li>intermediate cert and sign cert</li>
+        </ul>
+      </emu-clause>
+      <emu-clause id="sec-signatures-9-validating-the-digital-signature">
+        <h1>Validating the digital signature</h1>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-signatures-10-using-sigstore-for-signing">
+      <h1>Using Sigstore for signing</h1>
+      <p>Sigstore is an excellent free service for both signing of GIT commits as well as artefacts by using ephemeral certificates (very shortlived) and a certificate transparency log for validation and verification. Sigstore signatures contain timestamps from a timestamping service.</p>
+      <p>Sigstore lends itself very well to Open Source projects but not really commercial projects. The Sigstore platform can be deployed internally for enterprise use, but in that case will have the same problem as any internal PKI with establishing trust.</p>
+    </emu-clause>
+    <emu-clause id="sec-signatures-11-suggested-pki-setup">
+      <h1>Suggested PKI setup</h1>
+      <emu-clause id="sec-signatures-12-root-cert">
+        <h1>Root cert</h1>
+        <emu-clause id="sec-signatures-13-root-cert-validity-and-renewal">
+          <h1>Root cert validity and renewal</h1>
+        </emu-clause>
+      </emu-clause>
+      <emu-clause id="sec-signatures-14-intermediate-cert">
+        <h1>Intermediate cert</h1>
+        <emu-clause id="sec-signatures-15-intermediate-cert-validity-and-renewal">
+          <h1>Intermediate cert validity and renewal</h1>
+        </emu-clause>
+      </emu-clause>
+      <emu-clause id="sec-signatures-16-signature">
+        <h1>Signature</h1>
+        <emu-clause id="sec-signatures-17-time-stamp-services">
+          <h1>Time stamp services</h1>
+        </emu-clause>
+      </emu-clause>
+      <emu-clause id="sec-signatures-18-dns-entry">
+        <h1>DNS entry</h1>
+      </emu-clause>
+    </emu-clause>
+    <emu-clause id="sec-signatures-19-references">
+      <h1>References</h1>
+      <ul>
+        <li>IETF RFC DANE</li>
+        <li>IETF DANCE architecture (IETF draft)</li>
+        <li>IETF Digital signature</li>
+        <li>JSON web signatures (JWS) - <a href="https://datatracker.ietf.org/doc/html/rfc7515">https://datatracker.ietf.org/doc/html/rfc7515</a></li>
+        <li>JSON signature format (JSF) - <a href="https://cyberphone.github.io/doc/security/jsf.html">https://cyberphone.github.io/doc/security/jsf.html</a></li>
+        <li><a href="https://www.rfc-editor.org/rfc/rfc7030">IETF Enrollment over Secure Transport (EST) RFC 7030</a></li>
+      </ul>
+    </emu-clause>
   </emu-clause>
 </emu-clause>
-
-<emu-clause id="sec-normative-references">
-  <h1>Normative References</h1>
-  <p>The following referenced documents are indispensable for the application of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</p>
-  <p>
-    RFC 3986, <i>Uniform Resource Identifier (URI): Generic Syntax</i>.<br>
-    <a href="https://datatracker.ietf.org/doc/html/rfc3986">https://datatracker.ietf.org/doc/html/rfc3986</a>
-  </p>
+<emu-clause id="sec-tea-api">
+  <h1>The TEA API</h1>
+  <emu-clause id="sec-tea-api-cle">
+    <h1>CLE</h1>
+    <emu-clause id="sec-tea-op-getclebyproductreleaseid">
+      <h1>getCleByProductReleaseId</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/productRelease/{uuid}/cle</code></p>
+      <p>Get the CLE (Common Lifecycle Enumeration) data for a TEA Product Release</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Product Release in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>CLE data for the requested TEA Product Release found and returned</td>
+              <td><a href="#sec-tea-schema-cle"><code>cle</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getclebyproductid">
+      <h1>getCleByProductId</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/product/{uuid}/cle</code></p>
+      <p>Get the CLE (Common Lifecycle Enumeration) data for a TEA Product</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Product in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>CLE data for the requested TEA Product found and returned</td>
+              <td><a href="#sec-tea-schema-cle"><code>cle</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getclebycomponentid">
+      <h1>getCleByComponentId</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/component/{uuid}/cle</code></p>
+      <p>Get the CLE (Common Lifecycle Enumeration) data for a TEA Component</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Component in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>CLE data for the requested TEA Component found and returned</td>
+              <td><a href="#sec-tea-schema-cle"><code>cle</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getclebycomponentreleaseid">
+      <h1>getCleByComponentReleaseId</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/componentRelease/{uuid}/cle</code></p>
+      <p>Get the CLE (Common Lifecycle Enumeration) data for a TEA Component Release</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Component Release in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>CLE data for the requested TEA Component Release found and returned</td>
+              <td><a href="#sec-tea-schema-cle"><code>cle</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+  <emu-clause id="sec-tea-api-tea-artifact">
+    <h1>TEA Artifact</h1>
+    <emu-clause id="sec-tea-op-getlatestartifact">
+      <h1>getLatestArtifact</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/artifact/{uuid}/latest</code></p>
+      <p>Get metadata for latest revision of a specific TEA Artifact</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Artifact in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Artifact metadata found and returned</td>
+              <td><a href="#sec-tea-schema-artifact"><code>artifact</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getartifactbyversion">
+      <h1>getArtifactByVersion</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/artifact/{uuid}/{artifactVersion}</code></p>
+      <p>Get metadata for a specific revision of a specific TEA Artifact</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Artifact in the TEA server</td>
+            </tr>
+            <tr>
+              <td><code>artifactVersion</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td>integer</td>
+              <td>Version of TEA Artifact</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Artifact metadata found and returned</td>
+              <td><a href="#sec-tea-schema-artifact"><code>artifact</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+  <emu-clause id="sec-tea-api-tea-component">
+    <h1>TEA Component</h1>
+    <emu-clause id="sec-tea-op-getteacomponentbyid">
+      <h1>getTeaComponentById</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/component/{uuid}</code></p>
+      <p>Get a TEA Component</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Component in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Component found and returned</td>
+              <td><a href="#sec-tea-schema-component"><code>component</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getreleasesbycomponentid">
+      <h1>getReleasesByComponentId</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/component/{uuid}/releases</code></p>
+      <p>Get releases of the component</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Component in the TEA server</td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-queryteacomponents">
+      <h1>queryTeaComponents</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/components</code></p>
+      <p>Returns a list of TEA components. Note that multiple components may match.</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+  <emu-clause id="sec-tea-api-tea-component-release">
+    <h1>TEA Component Release</h1>
+    <emu-clause id="sec-tea-op-queryteacomponentreleases">
+      <h1>queryTeaComponentReleases</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/componentReleases</code></p>
+      <p>Returns a list of TEA component releases. Note that multiple component releases may match.</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getcomponentreleasebyid">
+      <h1>getComponentReleaseById</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/componentRelease/{uuid}</code></p>
+      <p>Get the TEA Component Release with its latest collection</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Component Release in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Component Release and its latest Collection found and returned</td>
+              <td><a href="#sec-tea-schema-component-release-with-collection"><code>component-release-with-collection</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getlatestcollection">
+      <h1>getLatestCollection</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/componentRelease/{uuid}/collection/latest</code></p>
+      <p>Get the latest TEA Collection belonging to the TEA Component Release</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Component Release in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Collection found and returned</td>
+              <td><a href="#sec-tea-schema-collection"><code>collection</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getcollectionsbyreleaseid">
+      <h1>getCollectionsByReleaseId</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/componentRelease/{uuid}/collections</code></p>
+      <p>Get the TEA Collections belonging to the TEA Component Release</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Component Release in the TEA server</td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getcollection">
+      <h1>getCollection</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/componentRelease/{uuid}/collection/{collectionVersion}</code></p>
+      <p>Get a specific Collection (by version) for a TEA Component Release by its UUID</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Collection in the TEA server</td>
+            </tr>
+            <tr>
+              <td><code>collectionVersion</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td>integer</td>
+              <td>Version of TEA Collection</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Collection Version found and returned</td>
+              <td><a href="#sec-tea-schema-collection"><code>collection</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+  <emu-clause id="sec-tea-api-tea-discovery">
+    <h1>TEA Discovery</h1>
+    <emu-clause id="sec-tea-op-discoverybytei">
+      <h1>discoveryByTei</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/discovery</code></p>
+      <p>Discovery endpoint which resolves TEI into product release UUID.</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>tei</code></td>
+              <td>query</td>
+              <td>Yes</td>
+              <td>string</td>
+              <td>Transparency Exchange Identifier (TEI) for the product being discovered. Provide the TEI as a URL-encoded string per RFC 3986, RFC 3987.</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+  <emu-clause id="sec-tea-api-tea-product">
+    <h1>TEA Product</h1>
+    <emu-clause id="sec-tea-op-getteaproductbyuuid">
+      <h1>getTeaProductByUuid</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/product/{uuid}</code></p>
+      <p>Get a TEA Product by UUID</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of the TEA product in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Product found and returned</td>
+              <td><a href="#sec-tea-schema-product"><code>product</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-queryteaproducts">
+      <h1>queryTeaProducts</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/products</code></p>
+      <p>Returns a list of TEA products. Note that multiple products may match.</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
+  <emu-clause id="sec-tea-api-tea-product-release">
+    <h1>TEA Product Release</h1>
+    <emu-clause id="sec-tea-op-getreleasesbyproductid">
+      <h1>getReleasesByProductId</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/product/{uuid}/releases</code></p>
+      <p>Get releases of the product</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Product in the TEA server</td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getteaproductreleasebyuuid">
+      <h1>getTeaProductReleaseByUuid</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/productRelease/{uuid}</code></p>
+      <p>Get a TEA Product Release</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Product Release in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Product Release found and returned</td>
+              <td><a href="#sec-tea-schema-productrelease"><code>productRelease</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-queryteaproductreleases">
+      <h1>queryTeaProductReleases</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/productReleases</code></p>
+      <p>Returns a list of TEA product releases. Note that multiple product releases may match.</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getlatestcollectionforproductrelease">
+      <h1>getLatestCollectionForProductRelease</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/productRelease/{uuid}/collection/latest</code></p>
+      <p>Get the latest TEA Collection belonging to the TEA Product Release</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Product Release in the TEA server</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Collection found and returned</td>
+              <td><a href="#sec-tea-schema-collection"><code>collection</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getcollectionsbyproductreleaseid">
+      <h1>getCollectionsByProductReleaseId</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/productRelease/{uuid}/collections</code></p>
+      <p>Get the TEA Collections belonging to the TEA Product Release</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Product Release in the TEA server</td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+            <tr>
+              <td><code></code></td>
+              <td></td>
+              <td>No</td>
+              <td>—</td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+    <emu-clause id="sec-tea-op-getcollectionforproductrelease">
+      <h1>getCollectionForProductRelease</h1>
+      <p><span class="tea-method">GET</span><code class="tea-path">/productRelease/{uuid}/collection/{collectionVersion}</code></p>
+      <p>Get a specific Collection (by version) for a TEA Product Release by its UUID</p>
+      <emu-table><emu-caption>Parameters</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>In</th>
+              <th>Required</th>
+              <th>Type</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>uuid</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+              <td>UUID of TEA Product Release in the TEA server</td>
+            </tr>
+            <tr>
+              <td><code>collectionVersion</code></td>
+              <td>path</td>
+              <td>Yes</td>
+              <td>integer</td>
+              <td>Version of TEA Collection</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+      <emu-table><emu-caption>Responses</emu-caption>
+        <table>
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Description</th>
+              <th>Schema</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><code>200</code></td>
+              <td>Requested TEA Collection Version found and returned</td>
+              <td><a href="#sec-tea-schema-collection"><code>collection</code></a></td>
+            </tr>
+            <tr>
+              <td><code>400</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+            <tr>
+              <td><code>404</code></td>
+              <td></td>
+              <td>—</td>
+            </tr>
+          </tbody>
+        </table>
+      </emu-table>
+    </emu-clause>
+  </emu-clause>
 </emu-clause>
-
-<emu-clause id="sec-overview">
-  <h1>Overview</h1>
-  <p>This section contains a non-normative overview of the Transparency Exchange API specification.</p>
-  <p>TODO</p>
+<emu-clause id="sec-tea-data-model">
+  <h1>Data model</h1>
+  <p>This section catalogues the named schemas declared in <code>components.schemas</code>.</p>
+  <emu-clause id="sec-tea-schema-artifact">
+    <h1>artifact</h1>
+    <p>A security-related document</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>uuid</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Required</td>
+            <td>The UUID of the TEA Artifact object. Together with *version* uniquely identifies the TEA Artifact.</td>
+          </tr>
+          <tr>
+            <td><code>version</code></td>
+            <td>integer</td>
+            <td>Optional</td>
+            <td>An integer with default value 1. Together with *uuid* uniquely identifies the TEA Artifact. This field can be used to designate successive, immutable revisions of an artefact content (e.g. an updated VEX file). </td>
+          </tr>
+          <tr>
+            <td><code>name</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Name of TEA Artifact</td>
+          </tr>
+          <tr>
+            <td><code>type</code></td>
+            <td><a href="#sec-tea-schema-artifact-type"><code>artifact-type</code></a></td>
+            <td>Required</td>
+            <td>Type of TEA Artifact</td>
+          </tr>
+          <tr>
+            <td><code>createdDate</code></td>
+            <td><a href="#sec-tea-schema-date-time"><code>date-time</code></a></td>
+            <td>Optional</td>
+            <td>The date when the TEA Artifact revision was created.</td>
+          </tr>
+          <tr>
+            <td><code>distributionIds</code></td>
+            <td>Array of <a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Optional</td>
+            <td>List of TEA Component Release distributions that this TEA Artifact applies to. If absent or empty, the TEA Artifact applies to all distributions. </td>
+          </tr>
+          <tr>
+            <td><code>formats</code></td>
+            <td>Array of <a href="#sec-tea-schema-artifact-format"><code>artifact-format</code></a></td>
+            <td>Required</td>
+            <td>List of objects with the same content, but in different formats. The order of the list has no significance. </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "uuid": "1cb47b95-8bf8-3bad-a5a4-0d54d86e10ce",
+  "name": "Build SBOM",
+  "type": "BOM",
+  "formats": [
+    {
+      "mediaType": "application/vnd.cyclonedx+xml",
+      "description": "CycloneDX SBOM (XML)",
+      "url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml",
+      "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc",
+      "checksums": [
+        {
+          "algType": "MD5",
+          "algValue": "2e1a525afc81b0a8ecff114b8b743de9"
+        },
+        {
+          "algType": "SHA-1",
+          "algValue": "5a7d4caef63c5c5ccdf07c39337323529eb5a770"
+        }
+      ]
+    }
+  ]
+}</pre></emu-example>
+    <emu-example><pre>{
+  "uuid": "dfa35519-9734-4259-bba1-3e825cf4be06",
+  "version": 7,
+  "name": "Vulnerability Disclosure Report",
+  "type": "VULNERABILITIES",
+  "formats": [
+    {
+      "mediaType": "application/vnd.cyclonedx+xml",
+      "description": "CycloneDX VDR (XML)",
+      "url": "https://logging.apache.org/cyclonedx/vdr.xml",
+      "checksums": [
+        {
+          "algType": "SHA-256",
+          "algValue": "75b81020b3917cb682b1a7605ade431e062f7a4c01a412f0b87543b6e995ad2a"
+        }
+      ]
+    }
+  ]
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-artifact-format">
+    <h1>artifact-format</h1>
+    <p>A security-related document in a specific format</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>mediaType</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>The Media Type of the document</td>
+          </tr>
+          <tr>
+            <td><code>description</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>A free text describing the TEA Artifact</td>
+          </tr>
+          <tr>
+            <td><code>url</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Direct download URL for the TEA Artifact</td>
+          </tr>
+          <tr>
+            <td><code>signatureUrl</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Direct download URL for an external signature of the TEA Artifact</td>
+          </tr>
+          <tr>
+            <td><code>checksums</code></td>
+            <td>Array of <a href="#sec-tea-schema-checksum"><code>checksum</code></a></td>
+            <td>Optional</td>
+            <td>List of checksums for the TEA Artifact</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-artifact-type">
+    <h1>artifact-type</h1>
+    <p>Specifies the type of external reference.</p>
+    <p><strong>Type:</strong> string</p>
+    <emu-table><emu-caption>Enumeration of possible values</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>ATTESTATION</code></td>
+          </tr>
+          <tr>
+            <td><code>BOM</code></td>
+          </tr>
+          <tr>
+            <td><code>BUILD_META</code></td>
+          </tr>
+          <tr>
+            <td><code>CERTIFICATION</code></td>
+          </tr>
+          <tr>
+            <td><code>FORMULATION</code></td>
+          </tr>
+          <tr>
+            <td><code>LICENSE</code></td>
+          </tr>
+          <tr>
+            <td><code>RELEASE_NOTES</code></td>
+          </tr>
+          <tr>
+            <td><code>SECURITY_TXT</code></td>
+          </tr>
+          <tr>
+            <td><code>THREAT_MODEL</code></td>
+          </tr>
+          <tr>
+            <td><code>VULNERABILITIES</code></td>
+          </tr>
+          <tr>
+            <td><code>OTHER</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-checksum">
+    <h1>checksum</h1>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>algType</code></td>
+            <td><a href="#sec-tea-schema-checksum-type"><code>checksum-type</code></a></td>
+            <td>Required</td>
+            <td>Checksum algorithm</td>
+          </tr>
+          <tr>
+            <td><code>algValue</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>Checksum value</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-checksum-type">
+    <h1>checksum-type</h1>
+    <p>Checksum algorithm</p>
+    <p><strong>Type:</strong> string</p>
+    <emu-table><emu-caption>Enumeration of possible values</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>MD5</code></td>
+          </tr>
+          <tr>
+            <td><code>SHA-1</code></td>
+          </tr>
+          <tr>
+            <td><code>SHA-256</code></td>
+          </tr>
+          <tr>
+            <td><code>SHA-384</code></td>
+          </tr>
+          <tr>
+            <td><code>SHA-512</code></td>
+          </tr>
+          <tr>
+            <td><code>SHA3-256</code></td>
+          </tr>
+          <tr>
+            <td><code>SHA3-384</code></td>
+          </tr>
+          <tr>
+            <td><code>SHA3-512</code></td>
+          </tr>
+          <tr>
+            <td><code>BLAKE2b-256</code></td>
+          </tr>
+          <tr>
+            <td><code>BLAKE2b-384</code></td>
+          </tr>
+          <tr>
+            <td><code>BLAKE2b-512</code></td>
+          </tr>
+          <tr>
+            <td><code>BLAKE3</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-cle">
+    <h1>cle</h1>
+    <p>Common Lifecycle Enumeration (CLE) object based on ECMA-428 TC54 TG3 CLE Specification v1.0.0. Contains lifecycle events and optional reusable definitions for a component or product.</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>events</code></td>
+            <td>Array of <a href="#sec-tea-schema-cle-event"><code>cle-event</code></a></td>
+            <td>Required</td>
+            <td>Ordered array of CLE Event objects representing lifecycle events. MUST be ordered by ID in descending order (newest events with highest IDs first). </td>
+          </tr>
+          <tr>
+            <td><code>definitions</code></td>
+            <td><a href="#sec-tea-schema-cle-definitions"><code>cle-definitions</code></a></td>
+            <td>Optional</td>
+            <td>Container for reusable policy definitions referenced by events</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "events": [
+    {
+      "id": 3,
+      "type": "endOfSupport",
+      "effective": "2025-06-01T00:00:00Z",
+      "versions": [
+        {
+          "range": "vers:npm/&gt;=1.0.0|&lt;2.0.0"
+        }
+      ],
+      "supportId": "standard",
+      "published": "2025-01-01T00:00:00Z"
+    },
+    {
+      "id": 2,
+      "type": "endOfDevelopment",
+      "effective": "2025-01-01T00:00:00Z",
+      "versions": [
+        {
+          "version": "1.0.0"
+        }
+      ],
+      "supportId": "standard",
+      "published": "2024-06-01T00:00:00Z"
+    },
+    {
+      "id": 1,
+      "type": "released",
+      "effective": "2024-01-01T00:00:00Z",
+      "version": "1.0.0",
+      "license": "Apache-2.0",
+      "published": "2024-01-01T00:00:00Z"
+    }
+  ],
+  "definitions": {
+    "support": [
+      {
+        "id": "standard",
+        "description": "Standard product support policy",
+        "url": "https://example.com/support/standard"
+      }
+    ]
+  }
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-cle-definitions">
+    <h1>cle-definitions</h1>
+    <p>Container for reusable CLE policy definitions</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>support</code></td>
+            <td>Array of <a href="#sec-tea-schema-cle-support-definition"><code>cle-support-definition</code></a></td>
+            <td>Optional</td>
+            <td>List of support policies</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-cle-event">
+    <h1>cle-event</h1>
+    <p>A discrete lifecycle event from the CLE specification</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>id</code></td>
+            <td>integer</td>
+            <td>Required</td>
+            <td>A unique, auto-incrementing integer identifier for the event</td>
+          </tr>
+          <tr>
+            <td><code>type</code></td>
+            <td><a href="#sec-tea-schema-cle-event-type"><code>cle-event-type</code></a></td>
+            <td>Required</td>
+            <td>The type of lifecycle event</td>
+          </tr>
+          <tr>
+            <td><code>effective</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>ISO 8601 timestamp (UTC) when the event takes effect</td>
+          </tr>
+          <tr>
+            <td><code>published</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>ISO 8601 timestamp (UTC) when the event was first published</td>
+          </tr>
+          <tr>
+            <td><code>version</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Version string (used by released event type)</td>
+          </tr>
+          <tr>
+            <td><code>versions</code></td>
+            <td>Array of <a href="#sec-tea-schema-cle-version-specifier"><code>cle-version-specifier</code></a></td>
+            <td>Optional</td>
+            <td>List of version specifiers affected by this event</td>
+          </tr>
+          <tr>
+            <td><code>supportId</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Reference to a support policy ID defined in the definitions section</td>
+          </tr>
+          <tr>
+            <td><code>license</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>License identifier (used by released event type)</td>
+          </tr>
+          <tr>
+            <td><code>supersededByVersion</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Version string that supersedes the affected versions (used by supersededBy event type)</td>
+          </tr>
+          <tr>
+            <td><code>identifiers</code></td>
+            <td>Array of <a href="#sec-tea-schema-identifier"><code>identifier</code></a></td>
+            <td>Optional</td>
+            <td>New identifiers for the component (used by componentRenamed event type)</td>
+          </tr>
+          <tr>
+            <td><code>eventId</code></td>
+            <td>integer</td>
+            <td>Optional</td>
+            <td>ID of the event being withdrawn (used by withdrawn event type)</td>
+          </tr>
+          <tr>
+            <td><code>reason</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Human-readable explanation (used by withdrawn event type)</td>
+          </tr>
+          <tr>
+            <td><code>description</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Human-readable description of the event</td>
+          </tr>
+          <tr>
+            <td><code>references</code></td>
+            <td>Array of string</td>
+            <td>Optional</td>
+            <td>List of URLs to supporting documentation</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "id": 1,
+  "type": "released",
+  "effective": "2024-01-01T00:00:00Z",
+  "version": "1.0.0",
+  "license": "MIT",
+  "published": "2023-06-01T00:00:00Z"
+}</pre></emu-example>
+    <emu-example><pre>{
+  "id": 3,
+  "type": "endOfSupport",
+  "effective": "2024-01-01T00:00:00Z",
+  "versions": [
+    {
+      "version": "1.0.0"
+    }
+  ],
+  "supportId": "standard",
+  "published": "2023-06-01T00:00:00Z"
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-cle-event-type">
+    <h1>cle-event-type</h1>
+    <p>The type of CLE lifecycle event</p>
+    <p><strong>Type:</strong> string</p>
+    <emu-table><emu-caption>Enumeration of possible values</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>released</code></td>
+          </tr>
+          <tr>
+            <td><code>endOfDevelopment</code></td>
+          </tr>
+          <tr>
+            <td><code>endOfSupport</code></td>
+          </tr>
+          <tr>
+            <td><code>endOfLife</code></td>
+          </tr>
+          <tr>
+            <td><code>endOfDistribution</code></td>
+          </tr>
+          <tr>
+            <td><code>endOfMarketing</code></td>
+          </tr>
+          <tr>
+            <td><code>supersededBy</code></td>
+          </tr>
+          <tr>
+            <td><code>componentRenamed</code></td>
+          </tr>
+          <tr>
+            <td><code>withdrawn</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-cle-support-definition">
+    <h1>cle-support-definition</h1>
+    <p>A support policy definition from CLE</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>id</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>Unique identifier for the support policy</td>
+          </tr>
+          <tr>
+            <td><code>description</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>Human-readable description of the policy</td>
+          </tr>
+          <tr>
+            <td><code>url</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>URL to detailed documentation about this support policy</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "id": "standard",
+  "description": "Standard product support policy",
+  "url": "https://example.com/support/standard"
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-cle-version-specifier">
+    <h1>cle-version-specifier</h1>
+    <p>A version specifier that can be either a single version or a version range</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>version</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>A specific version string</td>
+          </tr>
+          <tr>
+            <td><code>range</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>A version range in vers format (e.g. "vers:npm/&gt;=1.0.0|&lt;2.0.0")</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-collection">
+    <h1>collection</h1>
+    <p>A collection of security-related documents</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>uuid</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Optional</td>
+            <td>UUID of the TEA Collection object. This matches the UUID of the associated TEA Component Release or TEA Product Release object. When updating a collection, only the `version` is changed. </td>
+          </tr>
+          <tr>
+            <td><code>version</code></td>
+            <td>integer</td>
+            <td>Optional</td>
+            <td>TEA Collection version, incremented each time its content changes. Versions start with 1. </td>
+          </tr>
+          <tr>
+            <td><code>date</code></td>
+            <td><a href="#sec-tea-schema-date-time"><code>date-time</code></a></td>
+            <td>Optional</td>
+            <td>The date when the TEA Collection version was created.</td>
+          </tr>
+          <tr>
+            <td><code>belongsTo</code></td>
+            <td><a href="#sec-tea-schema-collection-belongs-to-type"><code>collection-belongs-to-type</code></a></td>
+            <td>Optional</td>
+            <td>Indicates whether this collection belongs to a Component Release or a Product Release</td>
+          </tr>
+          <tr>
+            <td><code>updateReason</code></td>
+            <td><a href="#sec-tea-schema-collection-update-reason"><code>collection-update-reason</code></a></td>
+            <td>Optional</td>
+            <td>Reason for the update/release of the TEA Collection object.</td>
+          </tr>
+          <tr>
+            <td><code>artifacts</code></td>
+            <td>Array of <a href="#sec-tea-schema-artifact"><code>artifact</code></a></td>
+            <td>Optional</td>
+            <td>List of TEA Artifact objects.</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "uuid": "4c72fe22-9d83-4c2f-8eba-d6db484f32c8",
+  "version": 10,
+  "date": "2024-12-13T00:00:00.000Z",
+  "updateReason": {
+    "type": "ARTIFACT_UPDATED",
+    "comment": "VDR file updated"
+  },
+  "artifacts": [
+    {
+      "uuid": "1cb47b95-8bf8-3bad-a5a4-0d54d86e10ce",
+      "name": "Build SBOM",
+      "type": "BOM",
+      "formats": [
+        {
+          "mediaType": "application/vnd.cyclonedx+xml",
+          "description": "CycloneDX SBOM (XML)",
+          "url": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml",
+          "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/logging/log4j/log4j-core/2.24.3/log4j-core-2.24.3-cyclonedx.xml.asc",
+          "checksums": [
+            {
+              "algType": "MD5",
+              "algValue": "2e1a525afc81b0a8ecff114b8b743de9"
+            },
+            {
+              "algType": "SHA-1",
+              "algValue": "5a7d4caef63c5c5ccdf07c39337323529eb5a770"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "uuid": "dfa35519-9734-4259-bba1-3e825cf4be06",
+      "version": 7,
+      "name": "Vulnerability Disclosure Report",
+      "type": "VULNERABILITIES",
+      "formats": [
+        {
+          "mediaType": "application/vnd.cyclonedx+xml",
+          "description": "CycloneDX VDR (XML)",
+          "url": "https://logging.apache.org/cyclonedx/vdr.xml",
+          "checksums": [
+            {
+              "algType": "SHA-256",
+              "algValue": "75b81020b3917cb682b1a7605ade431e062f7a4c01a412f0b87543b6e995ad2a"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-collection-belongs-to-type">
+    <h1>collection-belongs-to-type</h1>
+    <p>Indicates whether a collection belongs to a component release or a product release</p>
+    <p><strong>Type:</strong> string</p>
+    <emu-table><emu-caption>Enumeration of possible values</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>COMPONENT_RELEASE</code></td>
+          </tr>
+          <tr>
+            <td><code>PRODUCT_RELEASE</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-collection-update-reason">
+    <h1>collection-update-reason</h1>
+    <p>Reason for the update to the TEA collection</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>type</code></td>
+            <td><a href="#sec-tea-schema-collection-update-reason-type"><code>collection-update-reason-type</code></a></td>
+            <td>Optional</td>
+            <td>Type of update reason.</td>
+          </tr>
+          <tr>
+            <td><code>comment</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Free text description</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-collection-update-reason-type">
+    <h1>collection-update-reason-type</h1>
+    <p>Type of TEA collection update</p>
+    <p><strong>Type:</strong> string</p>
+    <emu-table><emu-caption>Enumeration of possible values</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>INITIAL_RELEASE</code></td>
+          </tr>
+          <tr>
+            <td><code>VEX_UPDATED</code></td>
+          </tr>
+          <tr>
+            <td><code>ARTIFACT_UPDATED</code></td>
+          </tr>
+          <tr>
+            <td><code>ARTIFACT_ADDED</code></td>
+          </tr>
+          <tr>
+            <td><code>ARTIFACT_REMOVED</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-compliance-document-type">
+    <h1>compliance-document-type</h1>
+    <p>Well-known compliance document types. When idType is COMPLIANCE_DOCUMENT, the idValue SHOULD be one of these values.</p>
+    <p><strong>Type:</strong> string</p>
+    <emu-table><emu-caption>Enumeration of possible values</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>SOC_2_TYPE_I</code></td>
+          </tr>
+          <tr>
+            <td><code>SOC_2_TYPE_II</code></td>
+          </tr>
+          <tr>
+            <td><code>SOC_3</code></td>
+          </tr>
+          <tr>
+            <td><code>ISO_27001</code></td>
+          </tr>
+          <tr>
+            <td><code>ISO_27017</code></td>
+          </tr>
+          <tr>
+            <td><code>ISO_27018</code></td>
+          </tr>
+          <tr>
+            <td><code>ISO_27701</code></td>
+          </tr>
+          <tr>
+            <td><code>ISO_42001</code></td>
+          </tr>
+          <tr>
+            <td><code>PCI_DSS</code></td>
+          </tr>
+          <tr>
+            <td><code>HIPAA</code></td>
+          </tr>
+          <tr>
+            <td><code>FedRAMP</code></td>
+          </tr>
+          <tr>
+            <td><code>GDPR</code></td>
+          </tr>
+          <tr>
+            <td><code>CSA_STAR</code></td>
+          </tr>
+          <tr>
+            <td><code>NIST_800_53</code></td>
+          </tr>
+          <tr>
+            <td><code>NIST_800_171</code></td>
+          </tr>
+          <tr>
+            <td><code>CMMC</code></td>
+          </tr>
+          <tr>
+            <td><code>HITRUST</code></td>
+          </tr>
+          <tr>
+            <td><code>TISAX</code></td>
+          </tr>
+          <tr>
+            <td><code>CYBER_ESSENTIALS</code></td>
+          </tr>
+          <tr>
+            <td><code>CYBER_ESSENTIALS_PLUS</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-component">
+    <h1>component</h1>
+    <p>A TEA component</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>uuid</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Required</td>
+            <td>A unique identifier for the TEA component</td>
+          </tr>
+          <tr>
+            <td><code>name</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>Component name</td>
+          </tr>
+          <tr>
+            <td><code>identifiers</code></td>
+            <td>Array of <a href="#sec-tea-schema-identifier"><code>identifier</code></a></td>
+            <td>Required</td>
+            <td>List of identifiers for the component</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "uuid": "3910e0fd-aff4-48d6-b75f-8bf6b84687f0",
+  "name": "Apache Log4j API",
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.logging.log4j/log4j-api"
+    }
+  ]
+}</pre></emu-example>
+    <emu-example><pre>{
+  "uuid": "b844c9bd-55d6-478c-af59-954a932b6ad3",
+  "name": "Apache Log4j Core",
+  "identifiers": [
+    {
+      "idType": "CPE",
+      "idValue": "cpe:2.3:a:apache:log4j"
+    },
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.logging.log4j/log4j-core"
+    }
+  ]
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-component-ref">
+    <h1>component-ref</h1>
+    <p>A reference to a TEA component or specific component release</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>uuid</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Required</td>
+            <td>A unique identifier for the TEA component</td>
+          </tr>
+          <tr>
+            <td><code>release</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Optional</td>
+            <td>Optional UUID of a specific release included in the product in the case where the product always include a specific release of a component. The product name should include a version identifier in this case. </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-component-release-with-collection">
+    <h1>component-release-with-collection</h1>
+    <p>A TEA Component Release combined with its latest collection</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>release</code></td>
+            <td><a href="#sec-tea-schema-release"><code>release</code></a></td>
+            <td>Required</td>
+            <td>The TEA Component Release information</td>
+          </tr>
+          <tr>
+            <td><code>latestCollection</code></td>
+            <td><a href="#sec-tea-schema-collection"><code>collection</code></a></td>
+            <td>Required</td>
+            <td>The latest TEA Collection for this component release</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "release": {
+    "uuid": "605d0ecb-1057-40e4-9abf-c400b10f0345",
+    "version": "11.0.7",
+    "createdDate": "2025-05-07T18:08:00.000Z",
+    "releaseDate": "2025-05-12T18:08:00.000Z",
+    "identifiers": [
+      {
+        "idType": "PURL",
+        "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.7"
+      }
+    ]
+  },
+  "latestCollection": {
+    "uuid": "605d0ecb-1057-40e4-9abf-c400b10f0345",
+    "version": 2,
+    "date": "2025-05-12T18:08:00.000Z",
+    "belongsTo": "COMPONENT_RELEASE",
+    "updateReason": {
+      "type": "INITIAL_RELEASE",
+      "comment": "Initial collection for this release"
+    },
+    "artifacts": [
+      {
+        "uuid": "1cb47b95-8bf8-3bad-a5a4-0d54d86e10ce",
+        "name": "Build SBOM",
+        "type": "BOM",
+        "formats": [
+          {
+            "mediaType": "application/vnd.cyclonedx+xml",
+            "description": "CycloneDX SBOM (XML)",
+            "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.7-cyclonedx.xml",
+            "checksums": [
+              {
+                "algType": "SHA-256",
+                "algValue": "9da736a1cdd27231e70187cbc67398d29ca0b714f885e7032da9f1fb247693c1"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "uuid": "dfa35519-9734-4259-bba1-3e825cf4be06",
+        "name": "Vulnerability Disclosure Report",
+        "type": "VULNERABILITIES",
+        "formats": [
+          {
+            "mediaType": "application/vnd.cyclonedx+xml",
+            "description": "CycloneDX VDR (XML)",
+            "url": "https://tomcat.apache.org/cyclonedx/vdr.xml",
+            "checksums": [
+              {
+                "algType": "SHA-256",
+                "algValue": "75b81020b3917cb682b1a7605ade431e062f7a4c01a412f0b87543b6e995ad2a"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-date-time">
+    <h1>date-time</h1>
+    <p>Timestamp</p>
+    <p><strong>Type:</strong> string</p>
+    <p><strong>Format:</strong> date-time</p>
+    <p><strong>Pattern:</strong> <code class="pattern">^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$</code></p>
+    <emu-example><pre>2024-03-20T15:30:00Z</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-discovery-info">
+    <h1>discovery-info</h1>
+    <p>Discovery information for a TEI</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>productReleaseUuid</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Required</td>
+            <td>UUID of the resolved TEA Product Release</td>
+          </tr>
+          <tr>
+            <td><code>servers</code></td>
+            <td>Array of <a href="#sec-tea-schema-tea-server-info"><code>tea-server-info</code></a></td>
+            <td>Required</td>
+            <td>Array of TEA server information</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-error-response">
+    <h1>error-response</h1>
+    <p>Error response</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>error</code></td>
+            <td><a href="#sec-tea-schema-unknown-error-type"><code>unknown-error-type</code></a></td>
+            <td>Required</td>
+            <td></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-identifier">
+    <h1>identifier</h1>
+    <p>An identifier with a specified type</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>idType</code></td>
+            <td><a href="#sec-tea-schema-identifier-type"><code>identifier-type</code></a></td>
+            <td>Optional</td>
+            <td>Type of identifier, e.g. `TEI`, `PURL`, `CPE`</td>
+          </tr>
+          <tr>
+            <td><code>idValue</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Identifier value</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-identifier-type">
+    <h1>identifier-type</h1>
+    <p>Enumeration of identifiers types</p>
+    <p><strong>Type:</strong> string</p>
+    <emu-table><emu-caption>Enumeration of possible values</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>CPE</code></td>
+          </tr>
+          <tr>
+            <td><code>TEI</code></td>
+          </tr>
+          <tr>
+            <td><code>PURL</code></td>
+          </tr>
+          <tr>
+            <td><code>COMPLIANCE_DOCUMENT</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-paginated-collection-response">
+    <h1>paginated-collection-response</h1>
+    <p>A paginated response containing TEA Collections</p>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-paginated-component-release-response">
+    <h1>paginated-component-release-response</h1>
+    <p>A paginated response containing TEA Component Releases</p>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-paginated-component-response">
+    <h1>paginated-component-response</h1>
+    <p>A paginated response containing TEA Components</p>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-paginated-product-release-response">
+    <h1>paginated-product-release-response</h1>
+    <p>A paginated response containing TEA Product Releases</p>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-paginated-product-response">
+    <h1>paginated-product-response</h1>
+    <p>A paginated response containing TEA Products</p>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-pagination-details">
+    <h1>pagination-details</h1>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>hasNext</code></td>
+            <td>boolean</td>
+            <td>Required</td>
+            <td>A flag (to aid clients) to know whether there is a next page of results to fetch. `nextPageToken` will always be supplied, hence this hint is included to aid clients. </td>
+          </tr>
+          <tr>
+            <td><code>nextPageToken</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>A token that can be used in a following request to retrieve the next page or results. It must always be supplied in responses. </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-product">
+    <h1>product</h1>
+    <p>A TEA product</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>uuid</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Required</td>
+            <td>A unique identifier for the TEA product</td>
+          </tr>
+          <tr>
+            <td><code>name</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>Product name</td>
+          </tr>
+          <tr>
+            <td><code>identifiers</code></td>
+            <td>Array of <a href="#sec-tea-schema-identifier"><code>identifier</code></a></td>
+            <td>Required</td>
+            <td>List of identifiers for the product, like TEI, CPE, PURL or other identifiers </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "uuid": "09e8c73b-ac45-4475-acac-33e6a7314e6d",
+  "name": "Apache Log4j 2",
+  "identifiers": [
+    {
+      "idType": "CPE",
+      "idValue": "cpe:2.3:a:apache:log4j"
+    },
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.logging.log4j/log4j-api"
+    }
+  ]
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-productrelease">
+    <h1>productRelease</h1>
+    <p>A specific release of a TEA product</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>uuid</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Required</td>
+            <td>A unique identifier for the TEA Product Release</td>
+          </tr>
+          <tr>
+            <td><code>product</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Optional</td>
+            <td>UUID of the TEA Product this release belongs to</td>
+          </tr>
+          <tr>
+            <td><code>productName</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Name of the TEA Product this release belongs to</td>
+          </tr>
+          <tr>
+            <td><code>version</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>Version number of the product release</td>
+          </tr>
+          <tr>
+            <td><code>createdDate</code></td>
+            <td><a href="#sec-tea-schema-date-time"><code>date-time</code></a></td>
+            <td>Required</td>
+            <td>Timestamp when this Product Release was created in TEA (for sorting purposes)</td>
+          </tr>
+          <tr>
+            <td><code>releaseDate</code></td>
+            <td><a href="#sec-tea-schema-date-time"><code>date-time</code></a></td>
+            <td>Optional</td>
+            <td>Timestamp of the product release</td>
+          </tr>
+          <tr>
+            <td><code>preRelease</code></td>
+            <td>boolean</td>
+            <td>Optional</td>
+            <td>A flag indicating pre-release (or beta) status. May be disabled after the creation of the release object, but can't be enabled after creation of an object. </td>
+          </tr>
+          <tr>
+            <td><code>identifiers</code></td>
+            <td>Array of <a href="#sec-tea-schema-identifier"><code>identifier</code></a></td>
+            <td>Optional</td>
+            <td>List of identifiers for the product release</td>
+          </tr>
+          <tr>
+            <td><code>components</code></td>
+            <td>Array of <a href="#sec-tea-schema-component-ref"><code>component-ref</code></a></td>
+            <td>Required</td>
+            <td>List of component references that compose this product release. A component reference can optionally include the UUID of a specific component release to pin the exact version. </td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "uuid": "123e4567-e89b-12d3-a456-426614174000",
+  "version": "2.24.3",
+  "createdDate": "2025-04-01T15:43:00.000Z",
+  "releaseDate": "2025-04-01T15:43:00.000Z",
+  "identifiers": [
+    {
+      "idType": "TEI",
+      "idValue": "tei:vendor:product@2.24.3"
+    }
+  ],
+  "components": [
+    {
+      "uuid": "3910e0fd-aff4-48d6-b75f-8bf6b84687f0"
+    },
+    {
+      "uuid": "b844c9bd-55d6-478c-af59-954a932b6ad3",
+      "release": "da89e38e-95e7-44ca-aa7d-f3b6b34c7fab"
+    }
+  ]
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-release">
+    <h1>release</h1>
+    <p>A TEA Component Release</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>uuid</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Required</td>
+            <td>A unique identifier for the TEA Component Release</td>
+          </tr>
+          <tr>
+            <td><code>component</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Optional</td>
+            <td>UUID of the TEA Component this release belongs to</td>
+          </tr>
+          <tr>
+            <td><code>componentName</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Name of the TEA Component this release belongs to</td>
+          </tr>
+          <tr>
+            <td><code>version</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>Version number</td>
+          </tr>
+          <tr>
+            <td><code>createdDate</code></td>
+            <td><a href="#sec-tea-schema-date-time"><code>date-time</code></a></td>
+            <td>Required</td>
+            <td>Timestamp when this Release was created in TEA (for sorting purposes)</td>
+          </tr>
+          <tr>
+            <td><code>releaseDate</code></td>
+            <td><a href="#sec-tea-schema-date-time"><code>date-time</code></a></td>
+            <td>Optional</td>
+            <td>Timestamp of the release</td>
+          </tr>
+          <tr>
+            <td><code>preRelease</code></td>
+            <td>boolean</td>
+            <td>Optional</td>
+            <td>A flag indicating pre-release (or beta) status. May be disabled after the creation of the release object, but can't be enabled after creation of an object. </td>
+          </tr>
+          <tr>
+            <td><code>identifiers</code></td>
+            <td>Array of <a href="#sec-tea-schema-identifier"><code>identifier</code></a></td>
+            <td>Optional</td>
+            <td>List of identifiers for the component</td>
+          </tr>
+          <tr>
+            <td><code>distributions</code></td>
+            <td>Array of <a href="#sec-tea-schema-release-distribution"><code>release-distribution</code></a></td>
+            <td>Optional</td>
+            <td>List of different formats of this component release</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "uuid": "605d0ecb-1057-40e4-9abf-c400b10f0345",
+  "version": "11.0.7",
+  "createdDate": "2025-05-07T18:08:00.000Z",
+  "releaseDate": "2025-05-12T18:08:00.000Z",
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.7"
+    }
+  ],
+  "distributions": [
+    {
+      "distributionId": "6a0d58e1-4896-4f1e-83f7-5feb6c032537",
+      "description": "Core binary distribution, zip archive",
+      "identifiers": [
+        {
+          "idType": "PURL",
+          "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6?type=zip"
+        }
+      ],
+      "checksums": [
+        {
+          "algType": "SHA_256",
+          "algValue": "9da736a1cdd27231e70187cbc67398d29ca0b714f885e7032da9f1fb247693c1"
+        }
+      ],
+      "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip",
+      "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip.asc"
+    },
+    {
+      "distributionId": "dba01c13-dd96-4928-be72-9c87ffa8cab8",
+      "description": "Core binary distribution, tar.gz archive",
+      "identifiers": [
+        {
+          "idType": "PURL",
+          "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6?type=tar.gz"
+        }
+      ],
+      "checksums": [
+        {
+          "algType": "SHA_256",
+          "algValue": "2fcece641c62ba1f28e1d7b257493151fc44f161fb391015ee6a95fa71632fb9"
+        }
+      ],
+      "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.tar.gz",
+      "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.tar.gz.asc"
+    },
+    {
+      "distributionId": "cfe068c2-fae7-43d0-97ec-5ea092454040",
+      "description": "Core binary distribution, Windows x64 zip archive",
+      "identifiers": [
+        {
+          "idType": "PURL",
+          "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6?classifier=windows-x64&amp;type=zip"
+        }
+      ],
+      "checksums": [
+        {
+          "algType": "SHA_256",
+          "algValue": "62a5c358d87a8ef21d7ec1b3b63c9bbb577453dda9c00cbb522b16cee6c23fc4"
+        }
+      ],
+      "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6-windows-x64.zip",
+      "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip.asc"
+    },
+    {
+      "distributionId": "de45ffaf-e4b5-47b5-be28-444a76df098e",
+      "description": "Core binary distribution, Windows Service Installer (MSI)",
+      "checksums": [
+        {
+          "algType": "SHA_512",
+          "algValue": "1d3824e7643c8aba455ab0bd9e67b14a60f2aaa6aa7775116bce40eb0579e8ced162a4f828051d3b867e96ee2858ec5da0cc654e83a83ba30823cbea0df4ff96"
+        }
+      ],
+      "url": "https://dlcdn.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe",
+      "signatureUrl": "https://downloads.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe.asc"
+    }
+  ]
+}</pre></emu-example>
+    <emu-example><pre>{
+  "uuid": "95f481df-f760-47f4-b2f2-f8b76d858450",
+  "version": "11.0.0-M26",
+  "createdDate": "2024-09-13T17:49:00.000Z",
+  "preRelease": true,
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.0-M26"
+    }
+  ]
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-release-distribution">
+    <h1>release-distribution</h1>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>distributionId</code></td>
+            <td><a href="#sec-tea-schema-uuid"><code>uuid</code></a></td>
+            <td>Required</td>
+            <td>A unique identifier for the TEA Distribution object</td>
+          </tr>
+          <tr>
+            <td><code>description</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Free-text description of the distribution.</td>
+          </tr>
+          <tr>
+            <td><code>identifiers</code></td>
+            <td>Array of <a href="#sec-tea-schema-identifier"><code>identifier</code></a></td>
+            <td>Optional</td>
+            <td>List of identifiers specific to this distribution.</td>
+          </tr>
+          <tr>
+            <td><code>url</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Direct download URL for the distribution.</td>
+          </tr>
+          <tr>
+            <td><code>signatureUrl</code></td>
+            <td>string</td>
+            <td>Optional</td>
+            <td>Direct download URL for the distribution's external signature.</td>
+          </tr>
+          <tr>
+            <td><code>checksums</code></td>
+            <td>Array of <a href="#sec-tea-schema-checksum"><code>checksum</code></a></td>
+            <td>Optional</td>
+            <td>List of checksums for the distribution.</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+    <emu-example><pre>{
+  "distributionId": "6a0d58e1-4896-4f1e-83f7-5feb6c032537",
+  "description": "Core binary distribution, zip archive",
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6?type=zip"
+    }
+  ],
+  "checksums": [
+    {
+      "algType": "SHA_256",
+      "algValue": "9da736a1cdd27231e70187cbc67398d29ca0b714f885e7032da9f1fb247693c1"
+    }
+  ],
+  "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip",
+  "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip.asc"
+}</pre></emu-example>
+    <emu-example><pre>{
+  "distributionId": "dba01c13-dd96-4928-be72-9c87ffa8cab8",
+  "description": "Core binary distribution, tar.gz archive",
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6?type=tar.gz"
+    }
+  ],
+  "checksums": [
+    {
+      "algType": "SHA_256",
+      "algValue": "2fcece641c62ba1f28e1d7b257493151fc44f161fb391015ee6a95fa71632fb9"
+    }
+  ],
+  "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.tar.gz",
+  "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.tar.gz.asc"
+}</pre></emu-example>
+    <emu-example><pre>{
+  "distributionId": "cfe068c2-fae7-43d0-97ec-5ea092454040",
+  "description": "Core binary distribution, Windows x64 zip archive",
+  "identifiers": [
+    {
+      "idType": "PURL",
+      "idValue": "pkg:maven/org.apache.tomcat/tomcat@11.0.6?classifier=windows-x64&amp;type=zip"
+    }
+  ],
+  "checksums": [
+    {
+      "algType": "SHA_256",
+      "algValue": "62a5c358d87a8ef21d7ec1b3b63c9bbb577453dda9c00cbb522b16cee6c23fc4"
+    }
+  ],
+  "url": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6-windows-x64.zip",
+  "signatureUrl": "https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/11.0.7/tomcat-11.0.6.zip.asc"
+}</pre></emu-example>
+    <emu-example><pre>{
+  "distributionId": "de45ffaf-e4b5-47b5-be28-444a76df098e",
+  "description": "Core binary distribution, Windows Service Installer (MSI)",
+  "checksums": [
+    {
+      "algType": "SHA_512",
+      "algValue": "1d3824e7643c8aba455ab0bd9e67b14a60f2aaa6aa7775116bce40eb0579e8ced162a4f828051d3b867e96ee2858ec5da0cc654e83a83ba30823cbea0df4ff96"
+    }
+  ],
+  "url": "https://dlcdn.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe",
+  "signatureUrl": "https://downloads.apache.org/tomcat/tomcat-11/v11.0.7/bin/apache-tomcat-11.0.7.exe.asc"
+}</pre></emu-example>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-tea-server-info">
+    <h1>tea-server-info</h1>
+    <p>TEA server information including URL, versions, and optional priority</p>
+    <p><strong>Type:</strong> object</p>
+    <emu-table><emu-caption>Properties</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Property</th>
+            <th>Type</th>
+            <th>Requirement</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>rootUrl</code></td>
+            <td>string</td>
+            <td>Required</td>
+            <td>Root URL of the TEA server for this TEI without trailing slash</td>
+          </tr>
+          <tr>
+            <td><code>versions</code></td>
+            <td>Array of string</td>
+            <td>Required</td>
+            <td>Supported TEA API versions at this server without v prefix</td>
+          </tr>
+          <tr>
+            <td><code>priority</code></td>
+            <td>number</td>
+            <td>Optional</td>
+            <td>Optional priority for this server (0.0 to 1.0, where 1.0 is highest priority)</td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-unknown-error-type">
+    <h1>unknown-error-type</h1>
+    <p>Classification of TEA error response</p>
+    <p><strong>Type:</strong> string</p>
+    <emu-table><emu-caption>Enumeration of possible values</emu-caption>
+      <table>
+        <thead>
+          <tr>
+            <th>Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>OBJECT_UNKNOWN</code></td>
+          </tr>
+          <tr>
+            <td><code>OBJECT_NOT_SHAREABLE</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </emu-table>
+  </emu-clause>
+  <emu-clause id="sec-tea-schema-uuid">
+    <h1>uuid</h1>
+    <p>A UUID</p>
+    <p><strong>Type:</strong> string</p>
+    <p><strong>Format:</strong> uuid</p>
+    <p><strong>Pattern:</strong> <code class="pattern">^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$</code></p>
+  </emu-clause>
 </emu-clause>
-
-<emu-clause id="sec-tea-specification">
-  <h1>Transparency Exchange API</h1>
-  <p>TODO</p>
-</emu-clause>
-
-<emu-annex id="sec-colophon">
-  <h1>Colophon</h1>
-  <p>This specification is authored on <a href="https://github.com/Ecma-TC54/ECMA-xxx-CLE">GitHub</a> in a plaintext source format called <a href="https://github.com/tc39/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMA specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/tc39/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this specification are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>.</p>
-  <p>We extend our gratitude to TC39 for their exceptional work in developing Ecmarkup, which has greatly facilitated TC54's successful adoption of this tool for the preparation and maintenance of our technical specifications.</p>
-</emu-annex>
-
 <emu-annex id="sec-bibliography">
   <h1>Bibliography</h1>
-  <p>TODO</p>
+  <p>
+    <em>SKELETON &mdash; to be authored by the working group.</em>
+  </p>
+  <ul>
+    <li>CycloneDX project &mdash; <a href="https://cyclonedx.org/">https://cyclonedx.org/</a>.</li>
+    <li>SPDX project &mdash; <a href="https://spdx.dev/">https://spdx.dev/</a>.</li>
+    <li>OpenVEX project &mdash; <a href="https://openvex.dev/">https://openvex.dev/</a>.</li>
+    <li>OASIS CSAF &mdash; <a href="https://oasis-open.github.io/csaf-documentation/">https://oasis-open.github.io/csaf-documentation/</a>.</li>
+    <li>NTIA Minimum Elements for an SBOM (2021).</li>
+    <li>Executive Order 14028 &mdash; Improving the Nation's Cybersecurity.</li>
+  </ul>
+</emu-annex>
+<emu-annex id="sec-colophon">
+  <h1>Colophon</h1>
+  <p> This specification is authored on <a href="https://github.com/Ecma-TC54/ECMA-xxx-TEA">GitHub</a> in a plaintext source format called <a href="https://github.com/tc39/ecmarkup">Ecmarkup</a>. Ecmarkup is an HTML and Markdown dialect that provides a framework and toolset for authoring ECMA specifications in plaintext and processing the specification into a full-featured HTML rendering that follows the editorial conventions for this document. Ecmarkup builds on and integrates a number of other formats and technologies including <a href="https://github.com/rbuckton/grammarkdown">Grammarkdown</a> for defining syntax and <a href="https://github.com/tc39/ecmarkdown">Ecmarkdown</a> for authoring algorithm steps. PDF renderings of this specification are produced using a print stylesheet which takes advantage of the CSS Paged Media specification and is converted using <a href="https://www.princexml.com/">PrinceXML</a>. </p>
+  <p> The body of this Specification is assembled from two sources of truth held in the <a href="https://github.com/CycloneDX/transparency-exchange-api">Transparency Exchange API</a> source repository: the OpenAPI document at <code>spec/openapi.yaml</code>, from which the API surface and data model are generated; and a set of Markdown documents which carry the narrative chapters and are imported verbatim. The build pipeline in this repository fetches both, converts them to Ecmarkup HTML, and renders them via the standard Ecmarkup toolchain. </p>
+  <p> We extend our gratitude to TC39 for their exceptional work in developing Ecmarkup, which has greatly facilitated TC54's successful adoption of this tool for the preparation and maintenance of our technical specifications. </p>
 </emu-annex>


### PR DESCRIPTION
### Summary

Wires this repository up to **render** the Transparency Exchange API specification while keeping [`CycloneDX/transparency-exchange-api`](https://github.com/CycloneDX/transparency-exchange-api) as the single source of truth for content.

That repo keeps owning the **content sources** — the OpenAPI document (`spec/openapi.yaml`) and the narrative Markdown chapters. This repo owns the **ECMA publication pipeline** (Markdown + OpenAPI → Ecmarkup → HTML → PDF) **and the hand-authored ECMA front/back matter in `excerpts/`** (header, scope, conformance, normative references, terms, bibliography, colophon) — using the same toolchain as ECMA-424.

Before this PR, `spec.html` here was a hand-authored stub with `TODO` bodies. After it, `spec.html` is generated from upstream and the build produces full single-page HTML, multipage HTML, and a watermark-free PDF via the existing `ghcr.io/ecma-tc54/princexml` CI container.

The pipeline, the inputs pulled from upstream (the curated Markdown allowlist with ordering/stable-ID rules, and exactly what's extracted from `spec/openapi.yaml`), and local build steps are all documented in the updated **[README](README.md)** — see *How this specification is built* and *What gets pulled from the TEA source*.

### Changes

- **`index.js`, `lib/`, `excerpts/`** — new build pipeline (see README *Layout* table).
- **`package.json`** — generator deps + `generate-spec`; `build-head`/`build-for-pdf` now generate first. Default `build-head` runs `--lint-spec` **without** `--strict` (matching ECMA-424); strict kept as `build-head-strict`.
- **`.github/workflows/build.yml`** — all actions pinned by commit digest (version in comment); Node read from `.nvmrc`. No job-topology changes.
- **`README.md`** — replaced the stale PURL placeholder with TEA content + build docs.
- **`.gitignore`** — ignores the `tea-source/` fetch cache.

### Notes for reviewers

1. **Source tracks upstream `main`, not a pinned ref** — reproducibility-unsafe for a real publication build. `TODO` in `index.js` to pin a tag/SHA before the first edition; on `main` for now so drafts stay current.
2. **`--strict` is off by default** — parenthesised narrative headings (e.g. *"TEA Collection object (TCO)"*) trip ecmarkup's `header-format` rule, surfacing as 14 non-fatal warnings. Reason is commented at the emission site in `lib/md-to-emu.js`.
3. **CI Node moved 18 → 20.14.0** as a side effect of reading `.nvmrc`. Code runs on both.
4. **`spec.html` is committed** as a generated artefact for diff-ability; CI regenerates it each build.

### Test plan

- [x] `npm run build` — single + multipage HTML, clean (14 lint warnings)
- [x] `npm run build-for-pdf` + `prince-books` — renders PDF locally, exit 0
- [ ] CI green (licensed Prince container produces the PDF artifact)